### PR TITLE
Fix SpeedHack FOV event type

### DIFF
--- a/src/main/java/org/main/vision/actions/SpeedHack.java
+++ b/src/main/java/org/main/vision/actions/SpeedHack.java
@@ -1,7 +1,7 @@
 package org.main.vision.actions;
 
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraftforge.client.event.FOVModifierEvent;
+import net.minecraftforge.client.event.FOVUpdateEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
@@ -53,7 +53,7 @@ public class SpeedHack extends ActionBase {
     }
 
     @SubscribeEvent
-    public void onFov(FOVModifierEvent event) {
+    public void onFov(FOVUpdateEvent event) {
         if (isEnabled()) {
             event.setNewfov(event.getFov() * FOV_MULTIPLIER);
         }


### PR DESCRIPTION
## Summary
- use `FOVUpdateEvent` instead of the non-existing `FOVModifierEvent`

## Testing
- `./gradlew clean build -x test` *(fails: could not complete build)*

------
https://chatgpt.com/codex/tasks/task_e_6858c68ec354832f9836729c0562c03f