### PR TITLE
Improve speedhack control and overlay

### DIFF
--- a/src/main/java/org/main/vision/PurpleButton.java
+++ b/src/main/java/org/main/vision/PurpleButton.java
@@ -1,0 +1,20 @@
+package org.main.vision;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.widget.button.Button;
+import net.minecraft.util.text.ITextComponent;
+
+/** Simple button with a purple color scheme. */
+public class PurpleButton extends Button {
+    public PurpleButton(int x, int y, int width, int height, ITextComponent title, IPressable onPress) {
+        super(x, y, width, height, title, onPress);
+    }
+
+    @Override
+    public void renderButton(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
+        int color = isHovered ? 0xFFAA55FF : 0xCC7722AA;
+        fill(ms, x, y, x + width, y + height, color);
+        drawCenteredString(ms, Minecraft.getInstance().font, getMessage(), x + width / 2, y + (height - 8) / 2, 0xFFFFFF);
+    }
+}

--- a/src/main/java/org/main/vision/VisionClient.java
+++ b/src/main/java/org/main/vision/VisionClient.java
@@ -24,10 +24,10 @@ public class VisionClient {
 
     @SubscribeEvent
     public static void onKeyInput(InputEvent.KeyInputEvent event) {
-        if (VisionKeybind.speedKey.isDown()) {
+        if (event.getKey() == VisionKeybind.speedKey.getKey().getValue() && event.getAction() == 1) {
             SPEED_HACK.toggle();
         }
-        if (VisionKeybind.menuKey.isDown()) {
+        if (event.getKey() == VisionKeybind.menuKey.getKey().getValue() && event.getAction() == 1) {
             Minecraft.getInstance().setScreen(new VisionMenuScreen());
         }
     }

--- a/src/main/java/org/main/vision/VisionMenuScreen.java
+++ b/src/main/java/org/main/vision/VisionMenuScreen.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.button.Button;
+import org.main.vision.PurpleButton;
 import net.minecraft.util.text.StringTextComponent;
 import org.main.vision.actions.SpeedHack;
 import org.main.vision.config.UIState;
@@ -25,7 +26,7 @@ public class VisionMenuScreen extends Screen {
     protected void init() {
         int width = 100;
         int height = 20;
-        this.hackButton = addButton(new Button(state.miscBarX, state.miscBarY + 20, width, height,
+        this.hackButton = addButton(new PurpleButton(state.miscBarX, state.miscBarY + 20, width, height,
                 getHackLabel(), b -> toggleHack()));
         hackButton.visible = state.hacksExpanded;
     }
@@ -81,7 +82,7 @@ public class VisionMenuScreen extends Screen {
     @Override
     public void render(MatrixStack matrices, int mouseX, int mouseY, float partialTicks) {
         this.renderBackground(matrices);
-        fill(matrices, state.miscBarX, state.miscBarY, state.miscBarX + 100, state.miscBarY + 20, 0x80000000);
+        fill(matrices, state.miscBarX, state.miscBarY, state.miscBarX + 100, state.miscBarY + 20, 0xAA5511AA);
         drawCenteredString(matrices, font, "Misc", state.miscBarX + 50, state.miscBarY + 6, 0xFFFFFF);
         if (state.hacksExpanded) {
             hackButton.visible = true;

--- a/src/main/java/org/main/vision/VisionOverlay.java
+++ b/src/main/java/org/main/vision/VisionOverlay.java
@@ -1,2 +1,28 @@
-package org.main.vision;public class VisionOverlay {
+package org.main.vision;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/** Overlay that displays active hacks in the top right corner. */
+@Mod.EventBusSubscriber(modid = "vision", value = Dist.CLIENT)
+public class VisionOverlay {
+    @SubscribeEvent
+    public static void onRenderOverlay(RenderGameOverlayEvent.Post event) {
+        if (event.getType() != RenderGameOverlayEvent.ElementType.ALL) return;
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.options.hideGui) return;
+        MatrixStack ms = event.getMatrixStack();
+        int width = mc.getWindow().getGuiScaledWidth();
+        int y = 5;
+        if (VisionClient.getSpeedHack().isEnabled()) {
+            String text = "SpeedHack";
+            int w = mc.font.width(text);
+            mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
+            y += mc.font.lineHeight;
+        }
+    }
 }

--- a/src/main/java/org/main/vision/actions/SpeedHack.java
+++ b/src/main/java/org/main/vision/actions/SpeedHack.java
@@ -22,8 +22,14 @@ public class SpeedHack extends ActionBase {
     private static final double SPEED_MULTIPLIER = 1.5D;
     private static final float FOV_MULTIPLIER = 1.2F;
 
+    private int packetBurst = 2; // number of additional movement packets per tick
+
     @Override
     protected void onEnable() {
+        PlayerEntity player = net.minecraft.client.Minecraft.getInstance().player;
+        if (player != null) {
+            apply(player);
+        }
     }
 
     @Override
@@ -40,7 +46,7 @@ public class SpeedHack extends ActionBase {
             attr.addPermanentModifier(new AttributeModifier(MODIFIER_ID, "SpeedHack", SPEED_MULTIPLIER - 1.0D, AttributeModifier.Operation.MULTIPLY_TOTAL));
         }
         if (player instanceof ClientPlayerEntity) {
-            sendExtraPacket((ClientPlayerEntity) player);
+            sendBurstPackets((ClientPlayerEntity) player);
         }
     }
 
@@ -51,10 +57,12 @@ public class SpeedHack extends ActionBase {
         }
     }
 
-    private void sendExtraPacket(ClientPlayerEntity player) {
+    private void sendBurstPackets(ClientPlayerEntity player) {
         ClientPlayNetHandler conn = player.connection;
         if (conn != null) {
-            conn.send(new CPlayerPacket.PositionRotationPacket(player.getX(), player.getY(), player.getZ(), player.yRot, player.xRot, player.isOnGround()));
+            for (int i = 0; i < packetBurst; i++) {
+                conn.send(new CPlayerPacket.PositionRotationPacket(player.getX(), player.getY(), player.getZ(), player.yRot, player.xRot, player.isOnGround()));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add purple-themed button UI
- update the menu style
- list active hacks via overlay
- refine SpeedHack with extra packets
- fix key handling logic

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: download did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_68599c32546c832fa0878465e9d2a5e2