### PR TITLE
Fix speed toggle logic and improve UI

### DIFF
--- a/src/main/java/org/main/vision/PurpleButton.java
+++ b/src/main/java/org/main/vision/PurpleButton.java
@@ -13,8 +13,9 @@ public class PurpleButton extends Button {
 
     @Override
     public void renderButton(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
-        int color = isHovered ? 0xFFAA55FF : 0xCC7722AA;
-        fill(ms, x, y, x + width, y + height, color);
+        int start = isHovered ? 0xFFAA55FF : 0xCC7722AA;
+        int end = isHovered ? 0xFF7744FF : 0xAA5511AA;
+        fillGradient(ms, x, y, x + width, y + height, start, end);
         drawCenteredString(ms, Minecraft.getInstance().font, getMessage(), x + width / 2, y + (height - 8) / 2, 0xFFFFFF);
     }
 }

--- a/src/main/java/org/main/vision/VisionClient.java
+++ b/src/main/java/org/main/vision/VisionClient.java
@@ -5,6 +5,7 @@ import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraft.client.Minecraft;
+import org.lwjgl.glfw.GLFW;
 import org.main.vision.actions.SpeedHack;
 
 /**
@@ -24,10 +25,10 @@ public class VisionClient {
 
     @SubscribeEvent
     public static void onKeyInput(InputEvent.KeyInputEvent event) {
-        if (event.getKey() == VisionKeybind.speedKey.getKey().getValue() && event.getAction() == 1) {
+        if (event.getKey() == VisionKeybind.speedKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
             SPEED_HACK.toggle();
         }
-        if (event.getKey() == VisionKeybind.menuKey.getKey().getValue() && event.getAction() == 1) {
+        if (event.getKey() == VisionKeybind.menuKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS) {
             Minecraft.getInstance().setScreen(new VisionMenuScreen());
         }
     }

--- a/src/main/java/org/main/vision/VisionMenuScreen.java
+++ b/src/main/java/org/main/vision/VisionMenuScreen.java
@@ -16,19 +16,23 @@ public class VisionMenuScreen extends Screen {
     private Button hackButton;
     private boolean dragging;
     private int dragOffsetX, dragOffsetY;
+    private float dropdownProgress;
+    private boolean dropdownTarget;
 
     public VisionMenuScreen() {
         super(new StringTextComponent("Vision Menu"));
         this.state = UIState.load();
+        this.dropdownTarget = state.hacksExpanded;
+        this.dropdownProgress = state.hacksExpanded ? 1.0f : 0.0f;
     }
 
     @Override
     protected void init() {
         int width = 100;
         int height = 20;
-        this.hackButton = addButton(new PurpleButton(state.miscBarX, state.miscBarY + 20, width, height,
+        this.hackButton = addButton(new PurpleButton(state.miscBarX, state.miscBarY + 20 + (int)(20 * dropdownProgress) - 20, width, height,
                 getHackLabel(), b -> toggleHack()));
-        hackButton.visible = state.hacksExpanded;
+        hackButton.visible = dropdownProgress > 0.05f;
     }
 
     private void toggleHack() {
@@ -47,7 +51,7 @@ public class VisionMenuScreen extends Screen {
         if (button == 0 && mouseX >= state.miscBarX && mouseX <= state.miscBarX + 100 && mouseY >= state.miscBarY && mouseY <= state.miscBarY + 20) {
             // click on bar toggles dropdown
             state.hacksExpanded = !state.hacksExpanded;
-            hackButton.visible = state.hacksExpanded;
+            dropdownTarget = state.hacksExpanded;
             state.save();
             dragging = true;
             dragOffsetX = (int)mouseX - state.miscBarX;
@@ -63,7 +67,7 @@ public class VisionMenuScreen extends Screen {
             state.miscBarX = (int)mouseX - dragOffsetX;
             state.miscBarY = (int)mouseY - dragOffsetY;
             hackButton.x = state.miscBarX;
-            hackButton.y = state.miscBarY + 20;
+            hackButton.y = state.miscBarY + 20 + (int)(20 * dropdownProgress) - 20;
             return true;
         }
         return super.mouseDragged(mouseX, mouseY, button, dragX, dragY);
@@ -84,9 +88,14 @@ public class VisionMenuScreen extends Screen {
         this.renderBackground(matrices);
         fill(matrices, state.miscBarX, state.miscBarY, state.miscBarX + 100, state.miscBarY + 20, 0xAA5511AA);
         drawCenteredString(matrices, font, "Misc", state.miscBarX + 50, state.miscBarY + 6, 0xFFFFFF);
-        if (state.hacksExpanded) {
-            hackButton.visible = true;
-        }
+        dropdownProgress += ((dropdownTarget ? 1.0f : 0.0f) - dropdownProgress) * 0.2f;
+        dropdownProgress = Math.max(0.0f, Math.min(1.0f, dropdownProgress));
+
+        int offsetY = (int)(20 * dropdownProgress);
+        hackButton.x = state.miscBarX;
+        hackButton.y = state.miscBarY + 20 + offsetY - 20;
+        hackButton.visible = dropdownProgress > 0.05f;
+
         super.render(matrices, mouseX, mouseY, partialTicks);
     }
 

--- a/src/main/java/org/main/vision/actions/ActionBase.java
+++ b/src/main/java/org/main/vision/actions/ActionBase.java
@@ -8,6 +8,10 @@ import net.minecraftforge.common.MinecraftForge;
 public abstract class ActionBase {
     private boolean enabled;
 
+    public ActionBase() {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
     /** Toggle the action on or off. */
     public void toggle() {
         setEnabled(!enabled);
@@ -20,10 +24,8 @@ public abstract class ActionBase {
         }
         this.enabled = enable;
         if (enable) {
-            MinecraftForge.EVENT_BUS.register(this);
             onEnable();
         } else {
-            MinecraftForge.EVENT_BUS.unregister(this);
             onDisable();
         }
     }

--- a/src/main/java/org/main/vision/actions/SpeedHack.java
+++ b/src/main/java/org/main/vision/actions/SpeedHack.java
@@ -43,7 +43,7 @@ public class SpeedHack extends ActionBase {
     private void apply(PlayerEntity player) {
         ModifiableAttributeInstance attr = player.getAttribute(Attributes.MOVEMENT_SPEED);
         if (attr != null && attr.getModifier(MODIFIER_ID) == null) {
-            attr.addPermanentModifier(new AttributeModifier(MODIFIER_ID, "SpeedHack", SPEED_MULTIPLIER - 1.0D, AttributeModifier.Operation.MULTIPLY_TOTAL));
+            attr.addTransientModifier(new AttributeModifier(MODIFIER_ID, "SpeedHack", SPEED_MULTIPLIER - 1.0D, AttributeModifier.Operation.MULTIPLY_TOTAL));
         }
         if (player instanceof ClientPlayerEntity) {
             sendBurstPackets((ClientPlayerEntity) player);


### PR DESCRIPTION
## Summary
- keep actions registered once and simplify toggle checks
- ensure speed modifier is temporary
- use GLFW constants and ignore keybinds if a GUI is open
- animate dropdown in the Vision menu
- use gradient coloring for buttons

## Testing
- `./gradlew classes`

------
https://chatgpt.com/codex/tasks/task_e_68599ed8e3c0832fa4518153a780ec98