### PR TITLE
Add hack settings UI and improved menu

### DIFF
--- a/src/main/java/org/main/vision/HackSettingsScreen.java
+++ b/src/main/java/org/main/vision/HackSettingsScreen.java
@@ -1,0 +1,44 @@
+package org.main.vision;
+
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.util.text.StringTextComponent;
+import org.main.vision.config.HackSettings;
+
+/** Simple screen to edit a single numeric value for a hack. */
+public class HackSettingsScreen extends Screen {
+    private final Screen parent;
+    private final Runnable saveCallback;
+    private TextFieldWidget field;
+    private final String label;
+    private final java.util.function.Supplier<Double> getter;
+    private final java.util.function.Consumer<Double> setter;
+
+    public HackSettingsScreen(Screen parent, String label, java.util.function.Supplier<Double> getter, java.util.function.Consumer<Double> setter, Runnable saveCallback) {
+        super(new StringTextComponent(label + " Settings"));
+        this.parent = parent;
+        this.label = label;
+        this.getter = getter;
+        this.setter = setter;
+        this.saveCallback = saveCallback;
+    }
+
+    @Override
+    protected void init() {
+        field = new TextFieldWidget(this.font, this.width / 2 - 40, this.height / 2 - 10, 80, 20, new StringTextComponent(label));
+        field.setValue(Double.toString(getter.get()));
+        this.addWidget(field);
+        this.addButton(new PurpleButton(this.width / 2 - 50, this.height / 2 + 20, 100, 20, new StringTextComponent("Back"), b -> onClose()));
+    }
+
+    @Override
+    public void onClose() {
+        try {
+            double v = Double.parseDouble(field.getValue());
+            setter.accept(v);
+        } catch (NumberFormatException ignored) {}
+        saveCallback.run();
+        this.minecraft.setScreen(parent);
+    }
+}
+

--- a/src/main/java/org/main/vision/VisionClient.java
+++ b/src/main/java/org/main/vision/VisionClient.java
@@ -11,6 +11,7 @@ import org.main.vision.actions.JumpHack;
 import org.main.vision.actions.FlyHack;
 import org.main.vision.actions.JesusHack;
 import org.main.vision.actions.NoFallHack;
+import org.main.vision.config.HackSettings;
 
 /**
  * Handles client-only events.
@@ -22,9 +23,11 @@ public class VisionClient {
     private static final FlyHack FLY_HACK = new FlyHack();
     private static final JesusHack JESUS_HACK = new JesusHack();
     private static final NoFallHack NOFALL_HACK = new NoFallHack();
+    private static HackSettings SETTINGS;
 
     static void init() {
         VisionKeybind.register();
+        SETTINGS = HackSettings.load();
     }
 
     public static SpeedHack getSpeedHack() {
@@ -45,6 +48,17 @@ public class VisionClient {
 
     public static NoFallHack getNoFallHack() {
         return NOFALL_HACK;
+    }
+
+    public static HackSettings getSettings() {
+        return SETTINGS;
+    }
+
+    /** Persist current settings to disk. */
+    public static void saveSettings() {
+        if (SETTINGS != null) {
+            SETTINGS.save();
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/org/main/vision/actions/FlyHack.java
+++ b/src/main/java/org/main/vision/actions/FlyHack.java
@@ -7,6 +7,8 @@ import net.minecraft.network.play.client.CPlayerPacket;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
+import org.main.vision.VisionClient;
+
 /**
  * Forcefully allows the player to fly by directly manipulating movement.
  */
@@ -17,18 +19,15 @@ public class FlyHack extends ActionBase {
      * Using 0.08 to roughly match Minecraft's gravity so
      * ascending and descending feel symmetrical.
      */
-    private static final double VERTICAL_SPEED = 0.5D;
 
     /**
      * Constant upward velocity applied every tick to counteract
      * gravity so the player can hover when no keys are pressed.
      */
-    private static final double HOVER_VELOCITY = 0.0D;
 
     /**
      * Horizontal speed applied when pressing WASD.
      */
-    private static final double HORIZONTAL_SPEED = 0.75D;
 
     @SubscribeEvent
     public void onTick(TickEvent.PlayerTickEvent event) {
@@ -40,14 +39,14 @@ public class FlyHack extends ActionBase {
         Minecraft mc = Minecraft.getInstance();
 
         // Start with a small upward push to negate gravity so the player hovers
-        double yMotion = HOVER_VELOCITY;
+        double yMotion = VisionClient.getSettings().flyHoverVelocity;
 
         // Modify the vertical motion based on input keys
         if (mc.options.keyJump.isDown()) {
-            yMotion += VERTICAL_SPEED;
+            yMotion += VisionClient.getSettings().flyVerticalSpeed;
         }
         if (mc.options.keyShift.isDown()) {
-            yMotion -= VERTICAL_SPEED;
+            yMotion -= VisionClient.getSettings().flyVerticalSpeed;
         }
 
         // Calculate horizontal velocity based on WASD input and player yaw
@@ -79,8 +78,9 @@ public class FlyHack extends ActionBase {
         // Normalize to keep diagonal movement consistent
         double mag = Math.sqrt(xMotion * xMotion + zMotion * zMotion);
         if (mag > 0.0D) {
-            xMotion = xMotion / mag * HORIZONTAL_SPEED;
-            zMotion = zMotion / mag * HORIZONTAL_SPEED;
+            double hs = VisionClient.getSettings().flyHorizontalSpeed;
+            xMotion = xMotion / mag * hs;
+            zMotion = zMotion / mag * hs;
         }
 
         // Apply the calculated velocity each tick for responsive flight

--- a/src/main/java/org/main/vision/actions/JesusHack.java
+++ b/src/main/java/org/main/vision/actions/JesusHack.java
@@ -8,6 +8,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
+import org.main.vision.VisionClient;
+
 /**
  * Allows the player to stand and walk on water blocks as if they were solid.
  */
@@ -23,7 +25,8 @@ public class JesusHack extends ActionBase {
 
         BlockPos below = new BlockPos(player.getX(), player.getY() - 0.1D, player.getZ());
         if (player.level.getBlockState(below).getBlock() == Blocks.WATER) {
-            if (player.getDeltaMovement().y < 0.0D) {
+            player.setOnGround(true);
+            if (player.getDeltaMovement().y < 0.0D && !player.input.jumping) {
                 player.setDeltaMovement(player.getDeltaMovement().x, 0.0D, player.getDeltaMovement().z);
             }
             player.fallDistance = 0.0f;

--- a/src/main/java/org/main/vision/actions/JumpHack.java
+++ b/src/main/java/org/main/vision/actions/JumpHack.java
@@ -6,12 +6,13 @@ import net.minecraft.network.play.client.CPlayerPacket;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
+import org.main.vision.VisionClient;
+
 /**
  * Applies a high jump velocity when the jump key is pressed.
  */
 public class JumpHack extends ActionBase {
 
-    private static final double JUMP_VELOCITY = 1.2D;
 
     /** Tracks whether the jump key was pressed last tick to
      *  detect rising-edge presses for consistent boosting. */
@@ -30,7 +31,8 @@ public class JumpHack extends ActionBase {
         // Trigger the boosted jump on the rising edge of the jump key
         // only when the player is on the ground to avoid mid-air boosts
         if (jumping && !wasJumping && player.isOnGround()) {
-            player.setDeltaMovement(player.getDeltaMovement().x, JUMP_VELOCITY, player.getDeltaMovement().z);
+            double vel = VisionClient.getSettings().jumpVelocity;
+            player.setDeltaMovement(player.getDeltaMovement().x, vel, player.getDeltaMovement().z);
             sendMovement(player);
         }
 

--- a/src/main/java/org/main/vision/actions/SpeedHack.java
+++ b/src/main/java/org/main/vision/actions/SpeedHack.java
@@ -11,6 +11,8 @@ import net.minecraftforge.client.event.FOVUpdateEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
+import org.main.vision.VisionClient;
+
 import java.util.UUID;
 
 /**
@@ -19,7 +21,6 @@ import java.util.UUID;
 public class SpeedHack extends ActionBase {
 
     private static final UUID MODIFIER_ID = UUID.fromString("96d899a2-1e4c-4e03-b1d0-596bcabc0123");
-    private static final double SPEED_MULTIPLIER = 1.5D;
     private static final float FOV_MULTIPLIER = 1.2F;
 
     private int packetBurst = 2; // number of additional movement packets per tick
@@ -42,8 +43,9 @@ public class SpeedHack extends ActionBase {
 
     private void apply(PlayerEntity player) {
         ModifiableAttributeInstance attr = player.getAttribute(Attributes.MOVEMENT_SPEED);
+        double multiplier = VisionClient.getSettings().speedMultiplier;
         if (attr != null && attr.getModifier(MODIFIER_ID) == null) {
-            attr.addTransientModifier(new AttributeModifier(MODIFIER_ID, "SpeedHack", SPEED_MULTIPLIER - 1.0D, AttributeModifier.Operation.MULTIPLY_TOTAL));
+            attr.addTransientModifier(new AttributeModifier(MODIFIER_ID, "SpeedHack", multiplier - 1.0D, AttributeModifier.Operation.MULTIPLY_TOTAL));
         }
         if (player instanceof ClientPlayerEntity) {
             sendBurstPackets((ClientPlayerEntity) player);

--- a/src/main/java/org/main/vision/config/HackSettings.java
+++ b/src/main/java/org/main/vision/config/HackSettings.java
@@ -1,0 +1,47 @@
+package org.main.vision.config;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.minecraftforge.fml.loading.FMLPaths;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Stores tweakable values for each hack and persists them to disk. */
+public class HackSettings {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final Path FILE = FMLPaths.CONFIGDIR.get().resolve("vision_hacks.json");
+
+    /** Movement speed multiplier for SpeedHack. */
+    public float speedMultiplier = 1.5f;
+    /** Jump velocity for JumpHack. */
+    public double jumpVelocity = 1.2D;
+    /** Horizontal speed for FlyHack. */
+    public double flyHorizontalSpeed = 0.75D;
+    /** Vertical speed for FlyHack. */
+    public double flyVerticalSpeed = 0.5D;
+    /** Hover velocity for FlyHack. */
+    public double flyHoverVelocity = 0.0D;
+
+    /** Load settings from disk. */
+    public static HackSettings load() {
+        if (Files.exists(FILE)) {
+            try {
+                return GSON.fromJson(Files.newBufferedReader(FILE), HackSettings.class);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return new HackSettings();
+    }
+
+    /** Save the settings to disk. */
+    public void save() {
+        try {
+            Files.write(FILE, GSON.toJson(this).getBytes());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/main/vision/mixin/MixinFlowingFluidBlock.java
+++ b/src/main/java/org/main/vision/mixin/MixinFlowingFluidBlock.java
@@ -1,0 +1,25 @@
+package org.main.vision.mixin;
+
+import net.minecraft.block.FlowingFluidBlock;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockReader;
+import net.minecraft.util.math.shapes.ISelectionContext;
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.util.math.shapes.VoxelShapes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.main.vision.VisionClient;
+
+/** Adds a collision box to water when Jesus hack is enabled. */
+@Mixin(FlowingFluidBlock.class)
+public abstract class MixinFlowingFluidBlock {
+    @Inject(method = "getCollisionShape", at = @At("HEAD"), cancellable = true)
+    private void vision$collision(BlockState state, IBlockReader world, BlockPos pos, ISelectionContext context, CallbackInfoReturnable<VoxelShape> cir) {
+        if (VisionClient.getJesusHack().isEnabled()) {
+            cir.setReturnValue(VoxelShapes.block());
+        }
+    }
+}

--- a/src/main/resources/vision.mixins.json
+++ b/src/main/resources/vision.mixins.json
@@ -7,6 +7,7 @@
   "mixins": [
   ],
   "client": [
+    "MixinFlowingFluidBlock"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary
- persist per-hack settings in `HackSettings`
- mix in a solid collision shape for water when Jesus hack is enabled
- add settings buttons and draggable dropdown improvements
- persist settings through new `HackSettingsScreen`

## Testing
- `./gradlew --no-daemon assemble`

------
https://chatgpt.com/codex/tasks/task_e_6859d2db0e2c832facf5f1359e4f3e62