### PR TITLE
Add NoDamage hack

### DIFF
--- a/src/main/java/org/main/vision/VisionClient.java
+++ b/src/main/java/org/main/vision/VisionClient.java
@@ -11,6 +11,7 @@ import org.main.vision.actions.JumpHack;
 import org.main.vision.actions.FlyHack;
 import org.main.vision.actions.JesusHack;
 import org.main.vision.actions.NoFallHack;
+import org.main.vision.actions.NoDamageHack;
 import org.main.vision.config.HackSettings;
 
 /**
@@ -23,6 +24,7 @@ public class VisionClient {
     private static final FlyHack FLY_HACK = new FlyHack();
     private static final JesusHack JESUS_HACK = new JesusHack();
     private static final NoFallHack NOFALL_HACK = new NoFallHack();
+    private static final NoDamageHack NODAMAGE_HACK = new NoDamageHack();
     private static HackSettings SETTINGS;
 
     static void init() {
@@ -48,6 +50,10 @@ public class VisionClient {
 
     public static NoFallHack getNoFallHack() {
         return NOFALL_HACK;
+    }
+
+    public static NoDamageHack getNoDamageHack() {
+        return NODAMAGE_HACK;
     }
 
     public static HackSettings getSettings() {
@@ -77,6 +83,9 @@ public class VisionClient {
         }
         if (event.getKey() == VisionKeybind.noFallKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
             NOFALL_HACK.toggle();
+        }
+        if (event.getKey() == VisionKeybind.noDamageKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
+            NODAMAGE_HACK.toggle();
         }
         if (event.getKey() == VisionKeybind.menuKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS) {
             Minecraft.getInstance().setScreen(new VisionMenuScreen());

--- a/src/main/java/org/main/vision/VisionKeybind.java
+++ b/src/main/java/org/main/vision/VisionKeybind.java
@@ -13,6 +13,7 @@ public class VisionKeybind {
     public static KeyBinding flyKey;
     public static KeyBinding jesusKey;
     public static KeyBinding noFallKey;
+    public static KeyBinding noDamageKey;
     public static KeyBinding menuKey;
 
     static void register() {
@@ -21,12 +22,14 @@ public class VisionKeybind {
         flyKey = new KeyBinding("key.vision.fly", GLFW.GLFW_KEY_J, "key.categories.vision");
         jesusKey = new KeyBinding("key.vision.jesus", GLFW.GLFW_KEY_K, "key.categories.vision");
         noFallKey = new KeyBinding("key.vision.nofall", GLFW.GLFW_KEY_L, "key.categories.vision");
+        noDamageKey = new KeyBinding("key.vision.nodamage", GLFW.GLFW_KEY_SEMICOLON, "key.categories.vision");
         menuKey = new KeyBinding("key.vision.menu", GLFW.GLFW_KEY_BACKSLASH, "key.categories.vision");
         ClientRegistry.registerKeyBinding(speedKey);
         ClientRegistry.registerKeyBinding(jumpKey);
         ClientRegistry.registerKeyBinding(flyKey);
         ClientRegistry.registerKeyBinding(jesusKey);
         ClientRegistry.registerKeyBinding(noFallKey);
+        ClientRegistry.registerKeyBinding(noDamageKey);
         ClientRegistry.registerKeyBinding(menuKey);
     }
 }

--- a/src/main/java/org/main/vision/VisionMenuScreen.java
+++ b/src/main/java/org/main/vision/VisionMenuScreen.java
@@ -19,11 +19,13 @@ public class VisionMenuScreen extends Screen {
     private PurpleButton flyButton;
     private PurpleButton jesusButton;
     private PurpleButton noFallButton;
+    private PurpleButton noDamageButton;
     private PurpleButton speedSettings;
     private PurpleButton jumpSettings;
     private PurpleButton flySettings;
     private PurpleButton jesusSettings;
     private PurpleButton noFallSettings;
+    private PurpleButton noDamageSettings;
     private static final int BUTTON_WIDTH = 100;
     private static final int BUTTON_HEIGHT = 20;
     private static final int BAR_WIDTH = BUTTON_WIDTH + 25;
@@ -69,8 +71,13 @@ public class VisionMenuScreen extends Screen {
         this.noFallSettings = addButton(new PurpleButton(state.miscBarX + width + 5, state.miscBarY + 100 + (int)(20 * dropdownProgress) - 20, 20, height,
                 new StringTextComponent("\u2699"), b -> openNoFallSettings()));
 
-        speedButton.visible = jumpButton.visible = flyButton.visible = jesusButton.visible = noFallButton.visible = dropdownProgress > 0.05f;
-        speedSettings.visible = jumpSettings.visible = flySettings.visible = jesusSettings.visible = noFallSettings.visible = dropdownProgress > 0.05f;
+        this.noDamageButton = addButton(new PurpleButton(state.miscBarX, state.miscBarY + 120 + (int)(20 * dropdownProgress) - 20, width, height,
+                getNoDamageLabel(), b -> toggleNoDamage()));
+        this.noDamageSettings = addButton(new PurpleButton(state.miscBarX + width + 5, state.miscBarY + 120 + (int)(20 * dropdownProgress) - 20, 20, height,
+                new StringTextComponent("\u2699"), b -> openNoDamageSettings()));
+
+        speedButton.visible = jumpButton.visible = flyButton.visible = jesusButton.visible = noFallButton.visible = noDamageButton.visible = dropdownProgress > 0.05f;
+        speedSettings.visible = jumpSettings.visible = flySettings.visible = jesusSettings.visible = noFallSettings.visible = noDamageSettings.visible = dropdownProgress > 0.05f;
     }
 
     private void toggleSpeed() {
@@ -104,6 +111,12 @@ public class VisionMenuScreen extends Screen {
         state.save();
     }
 
+    private void toggleNoDamage() {
+        VisionClient.getNoDamageHack().toggle();
+        noDamageButton.setMessage(getNoDamageLabel());
+        state.save();
+    }
+
     private void openSpeedSettings() {
         this.minecraft.setScreen(new HackSettingsScreen(this, "Speed", () -> (double)VisionClient.getSettings().speedMultiplier,
                 v -> {VisionClient.getSettings().speedMultiplier = v.floatValue();}, VisionClient::saveSettings));
@@ -129,6 +142,11 @@ public class VisionMenuScreen extends Screen {
                 v -> {}, VisionClient::saveSettings));
     }
 
+    private void openNoDamageSettings() {
+        this.minecraft.setScreen(new HackSettingsScreen(this, "NoDamage", () -> 0.0D,
+                v -> {}, VisionClient::saveSettings));
+    }
+
     private StringTextComponent getSpeedLabel() {
         return new StringTextComponent((VisionClient.getSpeedHack().isEnabled() ? "Disable" : "Enable") + " Speed");
     }
@@ -147,6 +165,10 @@ public class VisionMenuScreen extends Screen {
 
     private StringTextComponent getNoFallLabel() {
         return new StringTextComponent((VisionClient.getNoFallHack().isEnabled() ? "Disable" : "Enable") + " NoFall");
+    }
+
+    private StringTextComponent getNoDamageLabel() {
+        return new StringTextComponent((VisionClient.getNoDamageHack().isEnabled() ? "Disable" : "Enable") + " NoDamage");
     }
 
     @Override
@@ -172,22 +194,26 @@ public class VisionMenuScreen extends Screen {
             flyButton.x = state.miscBarX;
             jesusButton.x = state.miscBarX;
             noFallButton.x = state.miscBarX;
+            noDamageButton.x = state.miscBarX;
             speedSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
             jumpSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
             flySettings.x = state.miscBarX + BUTTON_WIDTH + 5;
             jesusSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
             noFallSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
+            noDamageSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
 
             speedButton.y = state.miscBarY + 20 + (int)(20 * dropdownProgress) - 20;
             jumpButton.y = state.miscBarY + 40 + (int)(20 * dropdownProgress) - 20;
             flyButton.y = state.miscBarY + 60 + (int)(20 * dropdownProgress) - 20;
             jesusButton.y = state.miscBarY + 80 + (int)(20 * dropdownProgress) - 20;
             noFallButton.y = state.miscBarY + 100 + (int)(20 * dropdownProgress) - 20;
+            noDamageButton.y = state.miscBarY + 120 + (int)(20 * dropdownProgress) - 20;
             speedSettings.y = speedButton.y;
             jumpSettings.y = jumpButton.y;
             flySettings.y = flyButton.y;
             jesusSettings.y = jesusButton.y;
             noFallSettings.y = noFallButton.y;
+            noDamageSettings.y = noDamageButton.y;
             return true;
         }
         return super.mouseDragged(mouseX, mouseY, button, dragX, dragY);
@@ -221,36 +247,42 @@ public class VisionMenuScreen extends Screen {
         flyButton.x = state.miscBarX;
         jesusButton.x = state.miscBarX;
         noFallButton.x = state.miscBarX;
+        noDamageButton.x = state.miscBarX;
         speedSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
         jumpSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
         flySettings.x = state.miscBarX + BUTTON_WIDTH + 5;
         jesusSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
         noFallSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
+        noDamageSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
 
         speedButton.y = state.miscBarY + 20 + offsetY - 20;
         jumpButton.y = state.miscBarY + 40 + offsetY - 20;
         flyButton.y = state.miscBarY + 60 + offsetY - 20;
         jesusButton.y = state.miscBarY + 80 + offsetY - 20;
         noFallButton.y = state.miscBarY + 100 + offsetY - 20;
+        noDamageButton.y = state.miscBarY + 120 + offsetY - 20;
         speedSettings.y = speedButton.y;
         jumpSettings.y = jumpButton.y;
         flySettings.y = flyButton.y;
         jesusSettings.y = jesusButton.y;
         noFallSettings.y = noFallButton.y;
+        noDamageSettings.y = noDamageButton.y;
 
         boolean vis = dropdownProgress > 0.05f;
-        speedButton.visible = jumpButton.visible = flyButton.visible = jesusButton.visible = noFallButton.visible = vis;
-        speedSettings.visible = jumpSettings.visible = flySettings.visible = jesusSettings.visible = noFallSettings.visible = vis;
+        speedButton.visible = jumpButton.visible = flyButton.visible = jesusButton.visible = noFallButton.visible = noDamageButton.visible = vis;
+        speedSettings.visible = jumpSettings.visible = flySettings.visible = jesusSettings.visible = noFallSettings.visible = noDamageSettings.visible = vis;
         speedButton.setAlpha(dropdownProgress);
         jumpButton.setAlpha(dropdownProgress);
         flyButton.setAlpha(dropdownProgress);
         jesusButton.setAlpha(dropdownProgress);
         noFallButton.setAlpha(dropdownProgress);
+        noDamageButton.setAlpha(dropdownProgress);
         speedSettings.setAlpha(dropdownProgress);
         jumpSettings.setAlpha(dropdownProgress);
         flySettings.setAlpha(dropdownProgress);
         jesusSettings.setAlpha(dropdownProgress);
         noFallSettings.setAlpha(dropdownProgress);
+        noDamageSettings.setAlpha(dropdownProgress);
 
         super.render(matrices, mouseX, mouseY, partialTicks);
     }

--- a/src/main/java/org/main/vision/VisionOverlay.java
+++ b/src/main/java/org/main/vision/VisionOverlay.java
@@ -48,5 +48,11 @@ public class VisionOverlay {
             mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
             y += mc.font.lineHeight;
         }
+        if (VisionClient.getNoDamageHack().isEnabled()) {
+            String text = "NoDamage";
+            int w = mc.font.width(text);
+            mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
+            y += mc.font.lineHeight;
+        }
     }
 }

--- a/src/main/java/org/main/vision/actions/NoDamageHack.java
+++ b/src/main/java/org/main/vision/actions/NoDamageHack.java
@@ -1,0 +1,21 @@
+package org.main.vision.actions;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+/**
+ * Negates all incoming damage to the local player.
+ */
+public class NoDamageHack extends ActionBase {
+
+    @SubscribeEvent
+    public void onLivingHurt(LivingHurtEvent event) {
+        if (!isEnabled()) return;
+        if (!(event.getEntityLiving() instanceof PlayerEntity)) return;
+        if (event.getEntityLiving() != Minecraft.getInstance().player) return;
+        event.setAmount(0.0F);
+        event.setCanceled(true);
+    }
+}


### PR DESCRIPTION
## Summary
- add a NoDamage hack that cancels all damage to the local player
- bind NoDamage to a new keybinding and toggle via Vision menu
- show NoDamage in the overlay

## Testing
- `sh gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6859de85b7bc832fa6bbaefe88d4fdeb