### PR TITLE
Improve hack settings menus

### DIFF
--- a/src/main/java/org/main/vision/HackSettingsScreen.java
+++ b/src/main/java/org/main/vision/HackSettingsScreen.java
@@ -1,5 +1,6 @@
 package org.main.vision;
 
+import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.util.text.StringTextComponent;
@@ -29,6 +30,14 @@ public class HackSettingsScreen extends Screen {
         field.setValue(Double.toString(getter.get()));
         this.addWidget(field);
         this.addButton(new PurpleButton(this.width / 2 - 50, this.height / 2 + 20, 100, 20, new StringTextComponent("Back"), b -> onClose()));
+    }
+
+    @Override
+    public void render(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
+        this.renderBackground(ms);
+        drawCenteredString(ms, this.font, new StringTextComponent(label + ":"), this.width / 2, this.height / 2 - 25, 0xFFFFFF);
+        field.render(ms, mouseX, mouseY, partialTicks);
+        super.render(ms, mouseX, mouseY, partialTicks);
     }
 
     @Override

--- a/src/main/java/org/main/vision/SpeedSettingsScreen.java
+++ b/src/main/java/org/main/vision/SpeedSettingsScreen.java
@@ -1,0 +1,58 @@
+package org.main.vision;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.util.text.StringTextComponent;
+import org.main.vision.config.HackSettings;
+import org.main.vision.VisionClient;
+import org.main.vision.PurpleButton;
+
+/** Settings screen for the Speed hack providing multiple tweakable options. */
+public class SpeedSettingsScreen extends Screen {
+    private final Screen parent;
+    private TextFieldWidget multiplierField;
+    private TextFieldWidget burstField;
+
+    public SpeedSettingsScreen(Screen parent) {
+        super(new StringTextComponent("Speed Settings"));
+        this.parent = parent;
+    }
+
+    @Override
+    protected void init() {
+        HackSettings cfg = VisionClient.getSettings();
+        int centerX = this.width / 2;
+        int centerY = this.height / 2;
+        multiplierField = new TextFieldWidget(this.font, centerX - 40, centerY - 20, 80, 20, new StringTextComponent("Multiplier"));
+        multiplierField.setValue(Float.toString(cfg.speedMultiplier));
+        burstField = new TextFieldWidget(this.font, centerX - 40, centerY + 5, 80, 20, new StringTextComponent("Packets"));
+        burstField.setValue(Integer.toString(VisionClient.getSpeedHack().getPacketBurst()));
+        addWidget(multiplierField);
+        addWidget(burstField);
+        addButton(new PurpleButton(centerX - 50, centerY + 35, 100, 20, new StringTextComponent("Back"), b -> onClose()));
+    }
+
+    @Override
+    public void render(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
+        this.renderBackground(ms);
+        drawCenteredString(ms, this.font, new StringTextComponent("Multiplier:"), this.width / 2, this.height / 2 - 32, 0xFFFFFF);
+        multiplierField.render(ms, mouseX, mouseY, partialTicks);
+        drawCenteredString(ms, this.font, new StringTextComponent("Extra Packets:"), this.width / 2, this.height / 2 - 7, 0xFFFFFF);
+        burstField.render(ms, mouseX, mouseY, partialTicks);
+        super.render(ms, mouseX, mouseY, partialTicks);
+    }
+
+    @Override
+    public void onClose() {
+        HackSettings cfg = VisionClient.getSettings();
+        try {
+            cfg.speedMultiplier = Float.parseFloat(multiplierField.getValue());
+        } catch (NumberFormatException ignored) {}
+        try {
+            VisionClient.getSpeedHack().setPacketBurst(Integer.parseInt(burstField.getValue()));
+        } catch (NumberFormatException ignored) {}
+        VisionClient.saveSettings();
+        this.minecraft.setScreen(parent);
+    }
+}

--- a/src/main/java/org/main/vision/VisionMenuScreen.java
+++ b/src/main/java/org/main/vision/VisionMenuScreen.java
@@ -9,6 +9,7 @@ import org.main.vision.config.UIState;
 import org.main.vision.actions.SpeedHack;
 import org.main.vision.VisionClient;
 import org.main.vision.HackSettingsScreen;
+import org.main.vision.SpeedSettingsScreen;
 
 /** Simple in-game menu with a draggable bar and dropdown for hacks. */
 public class VisionMenuScreen extends Screen {
@@ -118,8 +119,7 @@ public class VisionMenuScreen extends Screen {
     }
 
     private void openSpeedSettings() {
-        this.minecraft.setScreen(new HackSettingsScreen(this, "Speed", () -> (double)VisionClient.getSettings().speedMultiplier,
-                v -> {VisionClient.getSettings().speedMultiplier = v.floatValue();}, VisionClient::saveSettings));
+        this.minecraft.setScreen(new SpeedSettingsScreen(this));
     }
 
     private void openJumpSettings() {

--- a/src/main/java/org/main/vision/XRaySettingsScreen.java
+++ b/src/main/java/org/main/vision/XRaySettingsScreen.java
@@ -1,15 +1,25 @@
 package org.main.vision;
 
+import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.client.gui.widget.button.CheckboxButton;
 import net.minecraft.util.text.StringTextComponent;
-import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import org.main.vision.config.HackSettings;
+import org.main.vision.VisionClient;
+import org.main.vision.PurpleButton;
 
 /** Screen to configure the list of blocks highlighted by XRay hack. */
 public class XRaySettingsScreen extends Screen {
     private final Screen parent;
     private TextFieldWidget field;
+    private final Map<CheckboxButton, String> options = new HashMap<>();
+    private static final String[] COMMON_ORES = new String[] {
+            "minecraft:coal_ore", "minecraft:iron_ore", "minecraft:gold_ore",
+            "minecraft:diamond_ore", "minecraft:emerald_ore", "minecraft:lapis_ore",
+            "minecraft:redstone_ore", "minecraft:ancient_debris" };
 
     public XRaySettingsScreen(Screen parent) {
         super(new StringTextComponent("XRay Settings"));
@@ -19,16 +29,54 @@ public class XRaySettingsScreen extends Screen {
     @Override
     protected void init() {
         HackSettings cfg = VisionClient.getSettings();
-        field = new TextFieldWidget(this.font, this.width / 2 - 100, this.height / 2 - 10, 200, 20, new StringTextComponent("blocks"));
-        field.setValue(String.join(",", cfg.xrayBlocks));
+        int startY = this.height / 2 - 70;
+        int x = this.width / 2 - 100;
+        options.clear();
+        for (int i = 0; i < COMMON_ORES.length; i++) {
+            String id = COMMON_ORES[i];
+            CheckboxButton cb = new CheckboxButton(x, startY + i * 20, 200, 20, new StringTextComponent(id), cfg.xrayBlocks.contains(id));
+            options.put(cb, id);
+            this.addButton(cb);
+        }
+
+        field = new TextFieldWidget(this.font, x, startY + COMMON_ORES.length * 20 + 5, 140, 20, new StringTextComponent("block id"));
         this.addWidget(field);
-        this.addButton(new PurpleButton(this.width / 2 - 50, this.height / 2 + 20, 100, 20, new StringTextComponent("Back"), b -> onClose()));
+        this.addButton(new PurpleButton(x + 145, startY + COMMON_ORES.length * 20 + 5, 55, 20, new StringTextComponent("Add"), b -> addCustomBlock()));
+        this.addButton(new PurpleButton(this.width / 2 - 50, this.height - 30, 100, 20, new StringTextComponent("Back"), b -> onClose()));
+    }
+
+    private void addCustomBlock() {
+        String val = field.getValue().trim();
+        if (!val.isEmpty()) {
+            HackSettings cfg = VisionClient.getSettings();
+            for (String part : val.split("\\s*,\\s*")) {
+                if (!part.isEmpty() && !cfg.xrayBlocks.contains(part)) {
+                    cfg.xrayBlocks.add(part);
+                }
+            }
+            field.setValue("");
+        }
+    }
+
+    @Override
+    public void render(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
+        this.renderBackground(ms);
+        drawCenteredString(ms, this.font, new StringTextComponent("XRay Blocks"), this.width / 2, 15, 0xFFFFFF);
+        super.render(ms, mouseX, mouseY, partialTicks);
+        field.render(ms, mouseX, mouseY, partialTicks);
     }
 
     @Override
     public void onClose() {
         HackSettings cfg = VisionClient.getSettings();
-        cfg.xrayBlocks = Arrays.asList(field.getValue().split("\\s*,\\s*"));
+        // sync checkbox selections
+        for (Map.Entry<CheckboxButton, String> e : options.entrySet()) {
+            if (e.getKey().selected()) {
+                if (!cfg.xrayBlocks.contains(e.getValue())) cfg.xrayBlocks.add(e.getValue());
+            } else {
+                cfg.xrayBlocks.remove(e.getValue());
+            }
+        }
         VisionClient.saveSettings();
         this.minecraft.setScreen(parent);
     }

--- a/src/main/java/org/main/vision/actions/SpeedHack.java
+++ b/src/main/java/org/main/vision/actions/SpeedHack.java
@@ -25,6 +25,16 @@ public class SpeedHack extends ActionBase {
 
     private int packetBurst = 2; // number of additional movement packets per tick
 
+    /** @return number of extra movement packets sent each tick. */
+    public int getPacketBurst() {
+        return packetBurst;
+    }
+
+    /** Set the number of extra movement packets sent each tick. */
+    public void setPacketBurst(int burst) {
+        packetBurst = Math.max(0, burst);
+    }
+
     @Override
     protected void onEnable() {
         PlayerEntity player = net.minecraft.client.Minecraft.getInstance().player;


### PR DESCRIPTION
## Summary
- add rendering to HackSettingsScreen so text fields show
- add SpeedSettingsScreen for multiplier and packet burst
- call SpeedSettingsScreen from the main menu
- add getter/setter for SpeedHack packet bursts
- expand XRaySettingsScreen with block checkboxes and custom add field

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6859e662820c832fa3c8c6339921c670