### PR TITLE
Enable xray outline visibility and widen menus

### DIFF
--- a/src/main/java/org/main/vision/HackSettingsScreen.java
+++ b/src/main/java/org/main/vision/HackSettingsScreen.java
@@ -26,7 +26,9 @@ public class HackSettingsScreen extends Screen {
 
     @Override
     protected void init() {
-        field = new TextFieldWidget(this.font, this.width / 2 - 40, this.height / 2 - 10, 80, 20, new StringTextComponent(label));
+        int fieldWidth = 120;
+        field = new TextFieldWidget(this.font, this.width / 2 - fieldWidth / 2, this.height / 2 - 10, fieldWidth, 20, new StringTextComponent(label));
+        field.setMaxLength(32);
         field.setValue(Double.toString(getter.get()));
         this.addWidget(field);
         this.addButton(new PurpleButton(this.width / 2 - 50, this.height / 2 + 20, 100, 20, new StringTextComponent("Back"), b -> onClose()));

--- a/src/main/java/org/main/vision/SpeedSettingsScreen.java
+++ b/src/main/java/org/main/vision/SpeedSettingsScreen.java
@@ -24,9 +24,12 @@ public class SpeedSettingsScreen extends Screen {
         HackSettings cfg = VisionClient.getSettings();
         int centerX = this.width / 2;
         int centerY = this.height / 2;
-        multiplierField = new TextFieldWidget(this.font, centerX - 40, centerY - 20, 80, 20, new StringTextComponent("Multiplier"));
+        int fieldWidth = 120;
+        multiplierField = new TextFieldWidget(this.font, centerX - fieldWidth / 2, centerY - 20, fieldWidth, 20, new StringTextComponent("Multiplier"));
+        multiplierField.setMaxLength(32);
         multiplierField.setValue(Float.toString(cfg.speedMultiplier));
-        burstField = new TextFieldWidget(this.font, centerX - 40, centerY + 5, 80, 20, new StringTextComponent("Packets"));
+        burstField = new TextFieldWidget(this.font, centerX - fieldWidth / 2, centerY + 5, fieldWidth, 20, new StringTextComponent("Packets"));
+        burstField.setMaxLength(32);
         burstField.setValue(Integer.toString(VisionClient.getSpeedHack().getPacketBurst()));
         addWidget(multiplierField);
         addWidget(burstField);

--- a/src/main/java/org/main/vision/XRaySettingsScreen.java
+++ b/src/main/java/org/main/vision/XRaySettingsScreen.java
@@ -39,9 +39,11 @@ public class XRaySettingsScreen extends Screen {
             this.addButton(cb);
         }
 
-        field = new TextFieldWidget(this.font, x, startY + COMMON_ORES.length * 20 + 5, 140, 20, new StringTextComponent("block id"));
+        int fieldWidth = 180;
+        field = new TextFieldWidget(this.font, x, startY + COMMON_ORES.length * 20 + 5, fieldWidth, 20, new StringTextComponent("block id"));
+        field.setMaxLength(64);
         this.addWidget(field);
-        this.addButton(new PurpleButton(x + 145, startY + COMMON_ORES.length * 20 + 5, 55, 20, new StringTextComponent("Add"), b -> addCustomBlock()));
+        this.addButton(new PurpleButton(x + fieldWidth + 5, startY + COMMON_ORES.length * 20 + 5, 55, 20, new StringTextComponent("Add"), b -> addCustomBlock()));
         this.addButton(new PurpleButton(this.width / 2 - 50, this.height - 30, 100, 20, new StringTextComponent("Back"), b -> onClose()));
     }
 

--- a/src/main/java/org/main/vision/actions/XRayHack.java
+++ b/src/main/java/org/main/vision/actions/XRayHack.java
@@ -42,6 +42,9 @@ public class XRayHack extends ActionBase {
         }
 
         IRenderTypeBuffer.Impl buffer = mc.renderBuffers().bufferSource();
+
+        // Render outlines with depth testing disabled so they remain visible through walls
+        com.mojang.blaze3d.systems.RenderSystem.disableDepthTest();
         for (BlockPos pos : highlightCache) {
             AxisAlignedBB box = world.getBlockState(pos).getShape(world, pos).bounds()
                     .move(pos).inflate(0.002D)
@@ -49,5 +52,6 @@ public class XRayHack extends ActionBase {
             WorldRenderer.renderLineBox(ms, buffer.getBuffer(RenderType.lines()), box, 0.0f, 1.0f, 0.0f, 1.0f);
         }
         buffer.endBatch(RenderType.lines());
+        com.mojang.blaze3d.systems.RenderSystem.enableDepthTest();
     }
 }


### PR DESCRIPTION
## Summary
- render xray outlines with depth testing disabled so they appear through blocks
- widen textbox fields and add character limits to prevent text overflow

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6859e9385c30832f8178b447fdeff75a