### PR TITLE
Enhance XRay visuals and settings

### DIFF
--- a/src/main/java/org/main/vision/HackSettingsScreen.java
+++ b/src/main/java/org/main/vision/HackSettingsScreen.java
@@ -11,17 +11,22 @@ public class HackSettingsScreen extends Screen {
     private final Screen parent;
     private final Runnable saveCallback;
     private TextFieldWidget field;
+    private PurpleButton applyButton;
     private final String label;
     private final java.util.function.Supplier<Double> getter;
     private final java.util.function.Consumer<Double> setter;
+    private final double defaultValue;
+    private double originalValue;
 
-    public HackSettingsScreen(Screen parent, String label, java.util.function.Supplier<Double> getter, java.util.function.Consumer<Double> setter, Runnable saveCallback) {
+    public HackSettingsScreen(Screen parent, String label, java.util.function.Supplier<Double> getter,
+                              java.util.function.Consumer<Double> setter, Runnable saveCallback, double defaultValue) {
         super(new StringTextComponent(label + " Settings"));
         this.parent = parent;
         this.label = label;
         this.getter = getter;
         this.setter = setter;
         this.saveCallback = saveCallback;
+        this.defaultValue = defaultValue;
     }
 
     @Override
@@ -29,27 +34,44 @@ public class HackSettingsScreen extends Screen {
         int fieldWidth = 120;
         field = new TextFieldWidget(this.font, this.width / 2 - fieldWidth / 2, this.height / 2 - 10, fieldWidth, 20, new StringTextComponent(label));
         field.setMaxLength(32);
-        field.setValue(Double.toString(getter.get()));
+        originalValue = getter.get();
+        field.setValue(Double.toString(originalValue));
         this.addWidget(field);
-        this.addButton(new PurpleButton(this.width / 2 - 50, this.height / 2 + 20, 100, 20, new StringTextComponent("Back"), b -> onClose()));
+        int centerX = this.width / 2;
+        this.applyButton = this.addButton(new PurpleButton(centerX - 95, this.height / 2 + 20, 60, 20,
+                new StringTextComponent("Apply"), b -> apply()));
+        this.addButton(new PurpleButton(centerX - 30, this.height / 2 + 20, 60, 20,
+                new StringTextComponent("Reset"), b -> reset()));
+        this.addButton(new PurpleButton(centerX + 35, this.height / 2 + 20, 60, 20,
+                new StringTextComponent("Back"), b -> onClose()));
     }
 
     @Override
     public void render(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
         this.renderBackground(ms);
-        drawCenteredString(ms, this.font, new StringTextComponent(label + ":"), this.width / 2, this.height / 2 - 25, 0xFFFFFF);
+        drawCenteredString(ms, this.font, new StringTextComponent(label + ":"), this.width / 2, this.height / 2 - 30, 0xFFFFFF);
         field.render(ms, mouseX, mouseY, partialTicks);
+        applyButton.active = !field.getValue().equals(Double.toString(originalValue));
         super.render(ms, mouseX, mouseY, partialTicks);
     }
 
     @Override
     public void onClose() {
+        // Revert changes by simply ignoring field contents
+        this.minecraft.setScreen(parent);
+    }
+
+    private void apply() {
         try {
             double v = Double.parseDouble(field.getValue());
             setter.accept(v);
+            originalValue = v;
+            saveCallback.run();
         } catch (NumberFormatException ignored) {}
-        saveCallback.run();
-        this.minecraft.setScreen(parent);
+    }
+
+    private void reset() {
+        field.setValue(Double.toString(defaultValue));
     }
 }
 

--- a/src/main/java/org/main/vision/SpeedSettingsScreen.java
+++ b/src/main/java/org/main/vision/SpeedSettingsScreen.java
@@ -13,6 +13,11 @@ public class SpeedSettingsScreen extends Screen {
     private final Screen parent;
     private TextFieldWidget multiplierField;
     private TextFieldWidget burstField;
+    private PurpleButton applyButton;
+    private float originalMultiplier;
+    private int originalBurst;
+    private static final float DEFAULT_MULTIPLIER = 1.5f;
+    private static final int DEFAULT_BURST = 2;
 
     public SpeedSettingsScreen(Screen parent) {
         super(new StringTextComponent("Speed Settings"));
@@ -27,35 +32,53 @@ public class SpeedSettingsScreen extends Screen {
         int fieldWidth = 120;
         multiplierField = new TextFieldWidget(this.font, centerX - fieldWidth / 2, centerY - 20, fieldWidth, 20, new StringTextComponent("Multiplier"));
         multiplierField.setMaxLength(32);
-        multiplierField.setValue(Float.toString(cfg.speedMultiplier));
+        originalMultiplier = cfg.speedMultiplier;
+        multiplierField.setValue(Float.toString(originalMultiplier));
         burstField = new TextFieldWidget(this.font, centerX - fieldWidth / 2, centerY + 5, fieldWidth, 20, new StringTextComponent("Packets"));
         burstField.setMaxLength(32);
-        burstField.setValue(Integer.toString(VisionClient.getSpeedHack().getPacketBurst()));
+        originalBurst = VisionClient.getSpeedHack().getPacketBurst();
+        burstField.setValue(Integer.toString(originalBurst));
         addWidget(multiplierField);
         addWidget(burstField);
-        addButton(new PurpleButton(centerX - 50, centerY + 35, 100, 20, new StringTextComponent("Back"), b -> onClose()));
+        this.applyButton = addButton(new PurpleButton(centerX - 90, centerY + 35, 60, 20, new StringTextComponent("Apply"), b -> apply()));
+        addButton(new PurpleButton(centerX - 25, centerY + 35, 60, 20, new StringTextComponent("Reset"), b -> reset()));
+        addButton(new PurpleButton(centerX + 40, centerY + 35, 60, 20, new StringTextComponent("Back"), b -> onClose()));
     }
 
     @Override
     public void render(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
         this.renderBackground(ms);
-        drawCenteredString(ms, this.font, new StringTextComponent("Multiplier:"), this.width / 2, this.height / 2 - 32, 0xFFFFFF);
+        drawCenteredString(ms, this.font, new StringTextComponent("Multiplier:"), this.width / 2, this.height / 2 - 35, 0xFFFFFF);
         multiplierField.render(ms, mouseX, mouseY, partialTicks);
-        drawCenteredString(ms, this.font, new StringTextComponent("Extra Packets:"), this.width / 2, this.height / 2 - 7, 0xFFFFFF);
+        drawCenteredString(ms, this.font, new StringTextComponent("Extra Packets:"), this.width / 2, this.height / 2 - 10, 0xFFFFFF);
         burstField.render(ms, mouseX, mouseY, partialTicks);
+        boolean changed = !multiplierField.getValue().equals(Float.toString(originalMultiplier)) ||
+                !burstField.getValue().equals(Integer.toString(originalBurst));
+        applyButton.active = changed;
         super.render(ms, mouseX, mouseY, partialTicks);
     }
 
     @Override
     public void onClose() {
+        // ignore changes unless applied
+        this.minecraft.setScreen(parent);
+    }
+
+    private void apply() {
         HackSettings cfg = VisionClient.getSettings();
         try {
             cfg.speedMultiplier = Float.parseFloat(multiplierField.getValue());
+            originalMultiplier = cfg.speedMultiplier;
         } catch (NumberFormatException ignored) {}
         try {
             VisionClient.getSpeedHack().setPacketBurst(Integer.parseInt(burstField.getValue()));
+            originalBurst = VisionClient.getSpeedHack().getPacketBurst();
         } catch (NumberFormatException ignored) {}
         VisionClient.saveSettings();
-        this.minecraft.setScreen(parent);
+    }
+
+    private void reset() {
+        multiplierField.setValue(Float.toString(DEFAULT_MULTIPLIER));
+        burstField.setValue(Integer.toString(DEFAULT_BURST));
     }
 }

--- a/src/main/java/org/main/vision/VisionMenuScreen.java
+++ b/src/main/java/org/main/vision/VisionMenuScreen.java
@@ -124,22 +124,22 @@ public class VisionMenuScreen extends Screen {
 
     private void openJumpSettings() {
         this.minecraft.setScreen(new HackSettingsScreen(this, "Jump", () -> VisionClient.getSettings().jumpVelocity,
-                v -> {VisionClient.getSettings().jumpVelocity = v;}, VisionClient::saveSettings));
+                v -> {VisionClient.getSettings().jumpVelocity = v;}, VisionClient::saveSettings, 1.2D));
     }
 
     private void openFlySettings() {
         this.minecraft.setScreen(new HackSettingsScreen(this, "FlySpeed", () -> VisionClient.getSettings().flyHorizontalSpeed,
-                v -> {VisionClient.getSettings().flyHorizontalSpeed = v;}, VisionClient::saveSettings));
+                v -> {VisionClient.getSettings().flyHorizontalSpeed = v;}, VisionClient::saveSettings, 0.75D));
     }
 
     private void openJesusSettings() {
         this.minecraft.setScreen(new HackSettingsScreen(this, "Buoyancy", () -> VisionClient.getSettings().jesusBuoyancy,
-                v -> {VisionClient.getSettings().jesusBuoyancy = v;}, VisionClient::saveSettings));
+                v -> {VisionClient.getSettings().jesusBuoyancy = v;}, VisionClient::saveSettings, 0.0D));
     }
 
     private void openNoFallSettings() {
         this.minecraft.setScreen(new HackSettingsScreen(this, "Threshold", () -> VisionClient.getSettings().noFallThreshold,
-                v -> {VisionClient.getSettings().noFallThreshold = v;}, VisionClient::saveSettings));
+                v -> {VisionClient.getSettings().noFallThreshold = v;}, VisionClient::saveSettings, 2.0D));
     }
 
     private void openXRaySettings() {


### PR DESCRIPTION
## Summary
- colorize XRay outlines per block type and render them without depth masking
- add Apply/Reset buttons to generic `HackSettingsScreen`
- require applying changes for Speed and XRay settings
- include default values when opening numeric settings

## Testing
- `bash gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6859ec04cdb0832fa2b391aa99a64d0c