### PR TITLE
Fix xray visibility and simplify speed settings

### DIFF
--- a/src/main/java/org/main/vision/SpeedSettingsScreen.java
+++ b/src/main/java/org/main/vision/SpeedSettingsScreen.java
@@ -12,12 +12,9 @@ import org.main.vision.PurpleButton;
 public class SpeedSettingsScreen extends Screen {
     private final Screen parent;
     private TextFieldWidget multiplierField;
-    private TextFieldWidget burstField;
     private PurpleButton applyButton;
     private float originalMultiplier;
-    private int originalBurst;
     private static final float DEFAULT_MULTIPLIER = 1.5f;
-    private static final int DEFAULT_BURST = 2;
 
     public SpeedSettingsScreen(Screen parent) {
         super(new StringTextComponent("Speed Settings"));
@@ -30,16 +27,11 @@ public class SpeedSettingsScreen extends Screen {
         int centerX = this.width / 2;
         int centerY = this.height / 2;
         int fieldWidth = 120;
-        multiplierField = new TextFieldWidget(this.font, centerX - fieldWidth / 2, centerY - 20, fieldWidth, 20, new StringTextComponent("Multiplier"));
+        multiplierField = new TextFieldWidget(this.font, centerX - fieldWidth / 2, centerY - 10, fieldWidth, 20, new StringTextComponent("Multiplier"));
         multiplierField.setMaxLength(32);
         originalMultiplier = cfg.speedMultiplier;
         multiplierField.setValue(Float.toString(originalMultiplier));
-        burstField = new TextFieldWidget(this.font, centerX - fieldWidth / 2, centerY + 5, fieldWidth, 20, new StringTextComponent("Packets"));
-        burstField.setMaxLength(32);
-        originalBurst = VisionClient.getSpeedHack().getPacketBurst();
-        burstField.setValue(Integer.toString(originalBurst));
         addWidget(multiplierField);
-        addWidget(burstField);
         this.applyButton = addButton(new PurpleButton(centerX - 90, centerY + 35, 60, 20, new StringTextComponent("Apply"), b -> apply()));
         addButton(new PurpleButton(centerX - 25, centerY + 35, 60, 20, new StringTextComponent("Reset"), b -> reset()));
         addButton(new PurpleButton(centerX + 40, centerY + 35, 60, 20, new StringTextComponent("Back"), b -> onClose()));
@@ -48,12 +40,9 @@ public class SpeedSettingsScreen extends Screen {
     @Override
     public void render(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
         this.renderBackground(ms);
-        drawCenteredString(ms, this.font, new StringTextComponent("Multiplier:"), this.width / 2, this.height / 2 - 35, 0xFFFFFF);
+        drawCenteredString(ms, this.font, new StringTextComponent("Multiplier:"), this.width / 2, this.height / 2 - 25, 0xFFFFFF);
         multiplierField.render(ms, mouseX, mouseY, partialTicks);
-        drawCenteredString(ms, this.font, new StringTextComponent("Extra Packets:"), this.width / 2, this.height / 2 - 10, 0xFFFFFF);
-        burstField.render(ms, mouseX, mouseY, partialTicks);
-        boolean changed = !multiplierField.getValue().equals(Float.toString(originalMultiplier)) ||
-                !burstField.getValue().equals(Integer.toString(originalBurst));
+        boolean changed = !multiplierField.getValue().equals(Float.toString(originalMultiplier));
         applyButton.active = changed;
         super.render(ms, mouseX, mouseY, partialTicks);
     }
@@ -70,15 +59,10 @@ public class SpeedSettingsScreen extends Screen {
             cfg.speedMultiplier = Float.parseFloat(multiplierField.getValue());
             originalMultiplier = cfg.speedMultiplier;
         } catch (NumberFormatException ignored) {}
-        try {
-            VisionClient.getSpeedHack().setPacketBurst(Integer.parseInt(burstField.getValue()));
-            originalBurst = VisionClient.getSpeedHack().getPacketBurst();
-        } catch (NumberFormatException ignored) {}
         VisionClient.saveSettings();
     }
 
     private void reset() {
         multiplierField.setValue(Float.toString(DEFAULT_MULTIPLIER));
-        burstField.setValue(Integer.toString(DEFAULT_BURST));
     }
 }

--- a/src/main/java/org/main/vision/actions/XRayHack.java
+++ b/src/main/java/org/main/vision/actions/XRayHack.java
@@ -50,7 +50,7 @@ public class XRayHack extends ActionBase {
 
         MatrixStack ms = event.getMatrixStack();
         Vector3d cam = mc.gameRenderer.getMainCamera().getPosition();
-        int radius = 24;
+        int radius = Minecraft.getInstance().options.renderDistance * 16;
         highlightCache.clear();
         BlockPos start = new BlockPos(cam.x - radius, cam.y - radius, cam.z - radius);
         BlockPos end = new BlockPos(cam.x + radius, cam.y + radius, cam.z + radius);
@@ -62,8 +62,10 @@ public class XRayHack extends ActionBase {
 
         IRenderTypeBuffer.Impl buffer = mc.renderBuffers().bufferSource();
 
-        // Render outlines with depth testing disabled so they remain visible through walls
+        // Render outlines with depth testing and culling disabled so they remain visible through walls
         RenderSystem.disableDepthTest();
+        RenderSystem.disableCull();
+        RenderSystem.lineWidth(2.0F);
         RenderSystem.depthMask(false);
         for (BlockPos pos : highlightCache) {
             AxisAlignedBB box = world.getBlockState(pos).getShape(world, pos).bounds()
@@ -74,6 +76,8 @@ public class XRayHack extends ActionBase {
         }
         buffer.endBatch(RenderType.lines());
         RenderSystem.depthMask(true);
+        RenderSystem.lineWidth(1.0F);
+        RenderSystem.enableCull();
         RenderSystem.enableDepthTest();
     }
 }


### PR DESCRIPTION
## Summary
- ensure xray scan radius matches render distance and draw outlines over all blocks
- simplify the speed hack screen to only show multiplier

## Testing
- `./gradlew --version`

------
https://chatgpt.com/codex/tasks/task_e_6859efd15f60832faf4424fdc4675789