### PR TITLE
Add new hacks and categorize UI

### DIFF
--- a/src/main/java/org/main/vision/HackSettingsScreen.java
+++ b/src/main/java/org/main/vision/HackSettingsScreen.java
@@ -38,11 +38,14 @@ public class HackSettingsScreen extends Screen {
         field.setValue(Double.toString(originalValue));
         this.addWidget(field);
         int centerX = this.width / 2;
-        this.applyButton = this.addButton(new PurpleButton(centerX - 95, this.height / 2 + 20, 60, 20,
+        int y = this.height / 2 + 20;
+        this.applyButton = this.addButton(new PurpleButton(centerX - 60, y, 120, 20,
                 new StringTextComponent("Apply"), b -> apply()));
-        this.addButton(new PurpleButton(centerX - 30, this.height / 2 + 20, 60, 20,
+        y += 24;
+        this.addButton(new PurpleButton(centerX - 60, y, 120, 20,
                 new StringTextComponent("Reset"), b -> reset()));
-        this.addButton(new PurpleButton(centerX + 35, this.height / 2 + 20, 60, 20,
+        y += 24;
+        this.addButton(new PurpleButton(centerX - 60, y, 120, 20,
                 new StringTextComponent("Back"), b -> onClose()));
     }
 

--- a/src/main/java/org/main/vision/SpeedSettingsScreen.java
+++ b/src/main/java/org/main/vision/SpeedSettingsScreen.java
@@ -32,9 +32,12 @@ public class SpeedSettingsScreen extends Screen {
         originalMultiplier = cfg.speedMultiplier;
         multiplierField.setValue(Float.toString(originalMultiplier));
         addWidget(multiplierField);
-        this.applyButton = addButton(new PurpleButton(centerX - 90, centerY + 35, 60, 20, new StringTextComponent("Apply"), b -> apply()));
-        addButton(new PurpleButton(centerX - 25, centerY + 35, 60, 20, new StringTextComponent("Reset"), b -> reset()));
-        addButton(new PurpleButton(centerX + 40, centerY + 35, 60, 20, new StringTextComponent("Back"), b -> onClose()));
+        int y = centerY + 25;
+        this.applyButton = addButton(new PurpleButton(centerX - 60, y, 120, 20, new StringTextComponent("Apply"), b -> apply()));
+        y += 24;
+        addButton(new PurpleButton(centerX - 60, y, 120, 20, new StringTextComponent("Reset"), b -> reset()));
+        y += 24;
+        addButton(new PurpleButton(centerX - 60, y, 120, 20, new StringTextComponent("Back"), b -> onClose()));
     }
 
     @Override

--- a/src/main/java/org/main/vision/VisionClient.java
+++ b/src/main/java/org/main/vision/VisionClient.java
@@ -12,6 +12,9 @@ import org.main.vision.actions.FlyHack;
 import org.main.vision.actions.JesusHack;
 import org.main.vision.actions.NoFallHack;
 import org.main.vision.actions.XRayHack;
+import org.main.vision.actions.FullBrightHack;
+import org.main.vision.actions.ChestInteractHack;
+import org.main.vision.actions.BlinkHack;
 import org.main.vision.config.HackSettings;
 
 /**
@@ -25,6 +28,9 @@ public class VisionClient {
     private static final JesusHack JESUS_HACK = new JesusHack();
     private static final NoFallHack NOFALL_HACK = new NoFallHack();
     private static final XRayHack XRAY_HACK = new XRayHack();
+    private static final FullBrightHack FULLBRIGHT_HACK = new FullBrightHack();
+    private static final ChestInteractHack CHEST_HACK = new ChestInteractHack();
+    private static final BlinkHack BLINK_HACK = new BlinkHack();
     private static HackSettings SETTINGS;
 
     static void init() {
@@ -54,6 +60,18 @@ public class VisionClient {
 
     public static XRayHack getXRayHack() {
         return XRAY_HACK;
+    }
+
+    public static FullBrightHack getFullBrightHack() {
+        return FULLBRIGHT_HACK;
+    }
+
+    public static ChestInteractHack getChestHack() {
+        return CHEST_HACK;
+    }
+
+    public static BlinkHack getBlinkHack() {
+        return BLINK_HACK;
     }
 
     public static HackSettings getSettings() {
@@ -86,6 +104,15 @@ public class VisionClient {
         }
         if (event.getKey() == VisionKeybind.xrayKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
             XRAY_HACK.toggle();
+        }
+        if (event.getKey() == VisionKeybind.fullBrightKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
+            FULLBRIGHT_HACK.toggle();
+        }
+        if (event.getKey() == VisionKeybind.chestKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
+            CHEST_HACK.toggle();
+        }
+        if (event.getKey() == VisionKeybind.blinkKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
+            BLINK_HACK.toggle();
         }
         if (event.getKey() == VisionKeybind.menuKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS) {
             Minecraft.getInstance().setScreen(new VisionMenuScreen());

--- a/src/main/java/org/main/vision/VisionKeybind.java
+++ b/src/main/java/org/main/vision/VisionKeybind.java
@@ -14,6 +14,9 @@ public class VisionKeybind {
     public static KeyBinding jesusKey;
     public static KeyBinding noFallKey;
     public static KeyBinding xrayKey;
+    public static KeyBinding fullBrightKey;
+    public static KeyBinding chestKey;
+    public static KeyBinding blinkKey;
     public static KeyBinding menuKey;
 
     static void register() {
@@ -23,6 +26,9 @@ public class VisionKeybind {
         jesusKey = new KeyBinding("key.vision.jesus", GLFW.GLFW_KEY_K, "key.categories.vision");
         noFallKey = new KeyBinding("key.vision.nofall", GLFW.GLFW_KEY_L, "key.categories.vision");
         xrayKey = new KeyBinding("key.vision.xray", GLFW.GLFW_KEY_SEMICOLON, "key.categories.vision");
+        fullBrightKey = new KeyBinding("key.vision.fullbright", GLFW.GLFW_KEY_APOSTROPHE, "key.categories.vision");
+        chestKey = new KeyBinding("key.vision.chest", GLFW.GLFW_KEY_P, "key.categories.vision");
+        blinkKey = new KeyBinding("key.vision.blink", GLFW.GLFW_KEY_O, "key.categories.vision");
         menuKey = new KeyBinding("key.vision.menu", GLFW.GLFW_KEY_BACKSLASH, "key.categories.vision");
         ClientRegistry.registerKeyBinding(speedKey);
         ClientRegistry.registerKeyBinding(jumpKey);
@@ -30,6 +36,9 @@ public class VisionKeybind {
         ClientRegistry.registerKeyBinding(jesusKey);
         ClientRegistry.registerKeyBinding(noFallKey);
         ClientRegistry.registerKeyBinding(xrayKey);
+        ClientRegistry.registerKeyBinding(fullBrightKey);
+        ClientRegistry.registerKeyBinding(chestKey);
+        ClientRegistry.registerKeyBinding(blinkKey);
         ClientRegistry.registerKeyBinding(menuKey);
     }
 }

--- a/src/main/java/org/main/vision/VisionMenuScreen.java
+++ b/src/main/java/org/main/vision/VisionMenuScreen.java
@@ -27,26 +27,44 @@ public class VisionMenuScreen extends Screen {
     private PurpleButton jesusSettings;
     private PurpleButton noFallSettings;
     private PurpleButton xraySettings;
+    private PurpleButton fullBrightButton;
+    private PurpleButton chestButton;
+    private PurpleButton blinkButton;
     private static final int BUTTON_WIDTH = 100;
     private static final int BUTTON_HEIGHT = 20;
     private static final int BAR_WIDTH = BUTTON_WIDTH + 25;
     private boolean dragging;
+    private boolean draggingRender;
+    private boolean draggingUtil;
     private int dragOffsetX, dragOffsetY;
     private int dragStartX, dragStartY;
+    private int renderDragOffsetX, renderDragOffsetY;
+    private int renderDragStartX, renderDragStartY;
+    private int utilDragOffsetX, utilDragOffsetY;
+    private int utilDragStartX, utilDragStartY;
     private float dropdownProgress;
+    private float renderDropdownProgress;
+    private float utilDropdownProgress;
     private boolean dropdownTarget;
+    private boolean renderDropdownTarget;
+    private boolean utilDropdownTarget;
 
     public VisionMenuScreen() {
         super(new StringTextComponent("Vision Menu"));
         this.state = UIState.load();
         this.dropdownTarget = state.hacksExpanded;
+        this.renderDropdownTarget = state.renderExpanded;
+        this.utilDropdownTarget = state.utilExpanded;
         this.dropdownProgress = state.hacksExpanded ? 1.0f : 0.0f;
+        this.renderDropdownProgress = state.renderExpanded ? 1.0f : 0.0f;
+        this.utilDropdownProgress = state.utilExpanded ? 1.0f : 0.0f;
     }
 
     @Override
     protected void init() {
         int width = BUTTON_WIDTH;
         int height = BUTTON_HEIGHT;
+        // Movement bar
         this.speedButton = addButton(new PurpleButton(state.miscBarX, state.miscBarY + 20 + (int)(20 * dropdownProgress) - 20, width, height,
                 getSpeedLabel(), b -> toggleSpeed()));
         this.speedSettings = addButton(new PurpleButton(state.miscBarX + width + 5, state.miscBarY + 20 + (int)(20 * dropdownProgress) - 20, 20, height,
@@ -72,13 +90,29 @@ public class VisionMenuScreen extends Screen {
         this.noFallSettings = addButton(new PurpleButton(state.miscBarX + width + 5, state.miscBarY + 100 + (int)(20 * dropdownProgress) - 20, 20, height,
                 new StringTextComponent("\u2699"), b -> openNoFallSettings()));
 
-        this.xrayButton = addButton(new PurpleButton(state.miscBarX, state.miscBarY + 120 + (int)(20 * dropdownProgress) - 20, width, height,
+        this.blinkButton = addButton(new PurpleButton(state.miscBarX, state.miscBarY + 120 + (int)(20 * dropdownProgress) - 20, width, height,
+                getBlinkLabel(), b -> toggleBlink()));
+
+        speedButton.visible = jumpButton.visible = flyButton.visible = jesusButton.visible = noFallButton.visible = blinkButton.visible = dropdownProgress > 0.05f;
+        speedSettings.visible = jumpSettings.visible = flySettings.visible = jesusSettings.visible = noFallSettings.visible = dropdownProgress > 0.05f;
+
+        // Render bar
+        this.xrayButton = addButton(new PurpleButton(state.renderBarX, state.renderBarY + 20 + (int)(20 * renderDropdownProgress) - 20, width, height,
                 getXRayLabel(), b -> toggleXRay()));
-        this.xraySettings = addButton(new PurpleButton(state.miscBarX + width + 5, state.miscBarY + 120 + (int)(20 * dropdownProgress) - 20, 20, height,
+        this.xraySettings = addButton(new PurpleButton(state.renderBarX + width + 5, state.renderBarY + 20 + (int)(20 * renderDropdownProgress) - 20, 20, height,
                 new StringTextComponent("\u2699"), b -> openXRaySettings()));
 
-        speedButton.visible = jumpButton.visible = flyButton.visible = jesusButton.visible = noFallButton.visible = xrayButton.visible = dropdownProgress > 0.05f;
-        speedSettings.visible = jumpSettings.visible = flySettings.visible = jesusSettings.visible = noFallSettings.visible = xraySettings.visible = dropdownProgress > 0.05f;
+        this.fullBrightButton = addButton(new PurpleButton(state.renderBarX, state.renderBarY + 40 + (int)(20 * renderDropdownProgress) - 20, width, height,
+                getFullBrightLabel(), b -> toggleFullBright()));
+
+        xrayButton.visible = fullBrightButton.visible = renderDropdownProgress > 0.05f;
+        xraySettings.visible = renderDropdownProgress > 0.05f;
+
+        // Utility bar
+        this.chestButton = addButton(new PurpleButton(state.utilBarX, state.utilBarY + 20 + (int)(20 * utilDropdownProgress) - 20, width, height,
+                getChestLabel(), b -> toggleChest()));
+
+        chestButton.visible = utilDropdownProgress > 0.05f;
     }
 
     private void toggleSpeed() {
@@ -115,6 +149,24 @@ public class VisionMenuScreen extends Screen {
     private void toggleXRay() {
         VisionClient.getXRayHack().toggle();
         xrayButton.setMessage(getXRayLabel());
+        state.save();
+    }
+
+    private void toggleBlink() {
+        VisionClient.getBlinkHack().toggle();
+        blinkButton.setMessage(getBlinkLabel());
+        state.save();
+    }
+
+    private void toggleFullBright() {
+        VisionClient.getFullBrightHack().toggle();
+        fullBrightButton.setMessage(getFullBrightLabel());
+        state.save();
+    }
+
+    private void toggleChest() {
+        VisionClient.getChestHack().toggle();
+        chestButton.setMessage(getChestLabel());
         state.save();
     }
 
@@ -170,6 +222,18 @@ public class VisionMenuScreen extends Screen {
         return new StringTextComponent((VisionClient.getXRayHack().isEnabled() ? "Disable" : "Enable") + " XRay");
     }
 
+    private StringTextComponent getBlinkLabel() {
+        return new StringTextComponent((VisionClient.getBlinkHack().isEnabled() ? "Disable" : "Enable") + " Blink");
+    }
+
+    private StringTextComponent getFullBrightLabel() {
+        return new StringTextComponent((VisionClient.getFullBrightHack().isEnabled() ? "Disable" : "Enable") + " FullBright");
+    }
+
+    private StringTextComponent getChestLabel() {
+        return new StringTextComponent((VisionClient.getChestHack().isEnabled() ? "Disable" : "Enable") + " ChestLoot");
+    }
+
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
         if (button == 0 && mouseX >= state.miscBarX && mouseX <= state.miscBarX + BUTTON_WIDTH && mouseY >= state.miscBarY && mouseY <= state.miscBarY + 20) {
@@ -178,6 +242,22 @@ public class VisionMenuScreen extends Screen {
             dragOffsetY = (int)mouseY - state.miscBarY;
             dragStartX = (int)mouseX;
             dragStartY = (int)mouseY;
+            return true;
+        }
+        if (button == 0 && mouseX >= state.renderBarX && mouseX <= state.renderBarX + BUTTON_WIDTH && mouseY >= state.renderBarY && mouseY <= state.renderBarY + 20) {
+            draggingRender = true;
+            renderDragOffsetX = (int)mouseX - state.renderBarX;
+            renderDragOffsetY = (int)mouseY - state.renderBarY;
+            renderDragStartX = (int)mouseX;
+            renderDragStartY = (int)mouseY;
+            return true;
+        }
+        if (button == 0 && mouseX >= state.utilBarX && mouseX <= state.utilBarX + BUTTON_WIDTH && mouseY >= state.utilBarY && mouseY <= state.utilBarY + 20) {
+            draggingUtil = true;
+            utilDragOffsetX = (int)mouseX - state.utilBarX;
+            utilDragOffsetY = (int)mouseY - state.utilBarY;
+            utilDragStartX = (int)mouseX;
+            utilDragStartY = (int)mouseY;
             return true;
         }
         return super.mouseClicked(mouseX, mouseY, button);
@@ -193,26 +273,42 @@ public class VisionMenuScreen extends Screen {
             flyButton.x = state.miscBarX;
             jesusButton.x = state.miscBarX;
             noFallButton.x = state.miscBarX;
-            xrayButton.x = state.miscBarX;
+            blinkButton.x = state.miscBarX;
             speedSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
             jumpSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
             flySettings.x = state.miscBarX + BUTTON_WIDTH + 5;
             jesusSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
             noFallSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
-            xraySettings.x = state.miscBarX + BUTTON_WIDTH + 5;
 
             speedButton.y = state.miscBarY + 20 + (int)(20 * dropdownProgress) - 20;
             jumpButton.y = state.miscBarY + 40 + (int)(20 * dropdownProgress) - 20;
             flyButton.y = state.miscBarY + 60 + (int)(20 * dropdownProgress) - 20;
             jesusButton.y = state.miscBarY + 80 + (int)(20 * dropdownProgress) - 20;
             noFallButton.y = state.miscBarY + 100 + (int)(20 * dropdownProgress) - 20;
-            xrayButton.y = state.miscBarY + 120 + (int)(20 * dropdownProgress) - 20;
+            blinkButton.y = state.miscBarY + 120 + (int)(20 * dropdownProgress) - 20;
             speedSettings.y = speedButton.y;
             jumpSettings.y = jumpButton.y;
             flySettings.y = flyButton.y;
             jesusSettings.y = jesusButton.y;
             noFallSettings.y = noFallButton.y;
+            return true;
+        }
+        if (draggingRender) {
+            state.renderBarX = (int)mouseX - renderDragOffsetX;
+            state.renderBarY = (int)mouseY - renderDragOffsetY;
+            xrayButton.x = state.renderBarX;
+            fullBrightButton.x = state.renderBarX;
+            xraySettings.x = state.renderBarX + BUTTON_WIDTH + 5;
+            xrayButton.y = state.renderBarY + 20 + (int)(20 * renderDropdownProgress) - 20;
+            fullBrightButton.y = state.renderBarY + 40 + (int)(20 * renderDropdownProgress) - 20;
             xraySettings.y = xrayButton.y;
+            return true;
+        }
+        if (draggingUtil) {
+            state.utilBarX = (int)mouseX - utilDragOffsetX;
+            state.utilBarY = (int)mouseY - utilDragOffsetY;
+            chestButton.x = state.utilBarX;
+            chestButton.y = state.utilBarY + 20 + (int)(20 * utilDropdownProgress) - 20;
             return true;
         }
         return super.mouseDragged(mouseX, mouseY, button, dragX, dragY);
@@ -229,6 +325,24 @@ public class VisionMenuScreen extends Screen {
             state.save();
             return true;
         }
+        if (draggingRender) {
+            draggingRender = false;
+            if (Math.abs(mouseX - renderDragStartX) < 5 && Math.abs(mouseY - renderDragStartY) < 5) {
+                state.renderExpanded = !state.renderExpanded;
+                renderDropdownTarget = state.renderExpanded;
+            }
+            state.save();
+            return true;
+        }
+        if (draggingUtil) {
+            draggingUtil = false;
+            if (Math.abs(mouseX - utilDragStartX) < 5 && Math.abs(mouseY - utilDragStartY) < 5) {
+                state.utilExpanded = !state.utilExpanded;
+                utilDropdownTarget = state.utilExpanded;
+            }
+            state.save();
+            return true;
+        }
         return super.mouseReleased(mouseX, mouseY, button);
     }
 
@@ -236,9 +350,19 @@ public class VisionMenuScreen extends Screen {
     public void render(MatrixStack matrices, int mouseX, int mouseY, float partialTicks) {
         this.renderBackground(matrices);
         fill(matrices, state.miscBarX, state.miscBarY, state.miscBarX + BAR_WIDTH, state.miscBarY + 20, 0xAA5511AA);
-        drawCenteredString(matrices, font, "Misc", state.miscBarX + 50, state.miscBarY + 6, 0xFFFFFF);
+        drawCenteredString(matrices, font, "Movement", state.miscBarX + 50, state.miscBarY + 6, 0xFFFFFF);
         dropdownProgress += ((dropdownTarget ? 1.0f : 0.0f) - dropdownProgress) * 0.2f;
         dropdownProgress = Math.max(0.0f, Math.min(1.0f, dropdownProgress));
+
+        fill(matrices, state.renderBarX, state.renderBarY, state.renderBarX + BAR_WIDTH, state.renderBarY + 20, 0xAA5511AA);
+        drawCenteredString(matrices, font, "Render", state.renderBarX + 50, state.renderBarY + 6, 0xFFFFFF);
+        renderDropdownProgress += ((renderDropdownTarget ? 1.0f : 0.0f) - renderDropdownProgress) * 0.2f;
+        renderDropdownProgress = Math.max(0.0f, Math.min(1.0f, renderDropdownProgress));
+
+        fill(matrices, state.utilBarX, state.utilBarY, state.utilBarX + BAR_WIDTH, state.utilBarY + 20, 0xAA5511AA);
+        drawCenteredString(matrices, font, "Utility", state.utilBarX + 50, state.utilBarY + 6, 0xFFFFFF);
+        utilDropdownProgress += ((utilDropdownTarget ? 1.0f : 0.0f) - utilDropdownProgress) * 0.2f;
+        utilDropdownProgress = Math.max(0.0f, Math.min(1.0f, utilDropdownProgress));
 
         int offsetY = (int)(20 * dropdownProgress);
         speedButton.x = state.miscBarX;
@@ -246,42 +370,56 @@ public class VisionMenuScreen extends Screen {
         flyButton.x = state.miscBarX;
         jesusButton.x = state.miscBarX;
         noFallButton.x = state.miscBarX;
-        xrayButton.x = state.miscBarX;
+        blinkButton.x = state.miscBarX;
         speedSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
         jumpSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
         flySettings.x = state.miscBarX + BUTTON_WIDTH + 5;
         jesusSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
         noFallSettings.x = state.miscBarX + BUTTON_WIDTH + 5;
-        xraySettings.x = state.miscBarX + BUTTON_WIDTH + 5;
+        xrayButton.x = state.renderBarX;
+        fullBrightButton.x = state.renderBarX;
+        xraySettings.x = state.renderBarX + BUTTON_WIDTH + 5;
 
         speedButton.y = state.miscBarY + 20 + offsetY - 20;
         jumpButton.y = state.miscBarY + 40 + offsetY - 20;
         flyButton.y = state.miscBarY + 60 + offsetY - 20;
         jesusButton.y = state.miscBarY + 80 + offsetY - 20;
         noFallButton.y = state.miscBarY + 100 + offsetY - 20;
-        xrayButton.y = state.miscBarY + 120 + offsetY - 20;
+        blinkButton.y = state.miscBarY + 120 + offsetY - 20;
         speedSettings.y = speedButton.y;
         jumpSettings.y = jumpButton.y;
         flySettings.y = flyButton.y;
         jesusSettings.y = jesusButton.y;
         noFallSettings.y = noFallButton.y;
+        xrayButton.y = state.renderBarY + 20 + (int)(20 * renderDropdownProgress) - 20;
+        fullBrightButton.y = state.renderBarY + 40 + (int)(20 * renderDropdownProgress) - 20;
         xraySettings.y = xrayButton.y;
+        chestButton.x = state.utilBarX;
+        chestButton.y = state.utilBarY + 20 + (int)(20 * utilDropdownProgress) - 20;
 
         boolean vis = dropdownProgress > 0.05f;
-        speedButton.visible = jumpButton.visible = flyButton.visible = jesusButton.visible = noFallButton.visible = xrayButton.visible = vis;
-        speedSettings.visible = jumpSettings.visible = flySettings.visible = jesusSettings.visible = noFallSettings.visible = xraySettings.visible = vis;
+        boolean visR = renderDropdownProgress > 0.05f;
+        boolean visU = utilDropdownProgress > 0.05f;
+        speedButton.visible = jumpButton.visible = flyButton.visible = jesusButton.visible = noFallButton.visible = blinkButton.visible = vis;
+        speedSettings.visible = jumpSettings.visible = flySettings.visible = jesusSettings.visible = noFallSettings.visible = vis;
+        xrayButton.visible = fullBrightButton.visible = visR;
+        xraySettings.visible = visR;
+        chestButton.visible = visU;
         speedButton.setAlpha(dropdownProgress);
         jumpButton.setAlpha(dropdownProgress);
         flyButton.setAlpha(dropdownProgress);
         jesusButton.setAlpha(dropdownProgress);
         noFallButton.setAlpha(dropdownProgress);
-        xrayButton.setAlpha(dropdownProgress);
+        blinkButton.setAlpha(dropdownProgress);
         speedSettings.setAlpha(dropdownProgress);
         jumpSettings.setAlpha(dropdownProgress);
         flySettings.setAlpha(dropdownProgress);
         jesusSettings.setAlpha(dropdownProgress);
         noFallSettings.setAlpha(dropdownProgress);
-        xraySettings.setAlpha(dropdownProgress);
+        xrayButton.setAlpha(renderDropdownProgress);
+        fullBrightButton.setAlpha(renderDropdownProgress);
+        xraySettings.setAlpha(renderDropdownProgress);
+        chestButton.setAlpha(utilDropdownProgress);
 
         super.render(matrices, mouseX, mouseY, partialTicks);
     }

--- a/src/main/java/org/main/vision/VisionOverlay.java
+++ b/src/main/java/org/main/vision/VisionOverlay.java
@@ -54,5 +54,23 @@ public class VisionOverlay {
             mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
             y += mc.font.lineHeight;
         }
+        if (VisionClient.getFullBrightHack().isEnabled()) {
+            String text = "FullBright";
+            int w = mc.font.width(text);
+            mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
+            y += mc.font.lineHeight;
+        }
+        if (VisionClient.getBlinkHack().isEnabled()) {
+            String text = "Blink";
+            int w = mc.font.width(text);
+            mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
+            y += mc.font.lineHeight;
+        }
+        if (VisionClient.getChestHack().isEnabled()) {
+            String text = "ChestInteract";
+            int w = mc.font.width(text);
+            mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
+            y += mc.font.lineHeight;
+        }
     }
 }

--- a/src/main/java/org/main/vision/actions/BlinkHack.java
+++ b/src/main/java/org/main/vision/actions/BlinkHack.java
@@ -1,0 +1,29 @@
+package org.main.vision.actions;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.IPacket;
+import java.util.LinkedList;
+import java.util.Queue;
+
+/** Buffers outgoing packets until disabled. */
+public class BlinkHack extends ActionBase {
+    private final Queue<IPacket<?>> queue = new LinkedList<>();
+
+    public static boolean handleSend(IPacket<?> packet) {
+        BlinkHack hack = org.main.vision.VisionClient.getBlinkHack();
+        if (hack.isEnabled()) {
+            hack.queue.add(packet);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected void onDisable() {
+        NetworkManager nm = Minecraft.getInstance().getConnection().getConnection();
+        while (!queue.isEmpty()) {
+            nm.send(queue.poll());
+        }
+    }
+}

--- a/src/main/java/org/main/vision/actions/ChestInteractHack.java
+++ b/src/main/java/org/main/vision/actions/ChestInteractHack.java
@@ -1,0 +1,31 @@
+package org.main.vision.actions;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.inventory.ChestScreen;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.container.ChestContainer;
+import net.minecraft.inventory.container.ContainerType;
+import net.minecraft.tileentity.ChestTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+/** Opens chests client-side when clicked. */
+public class ChestInteractHack extends ActionBase {
+    @SubscribeEvent
+    public void onRightClick(PlayerInteractEvent.RightClickBlock event) {
+        if (!isEnabled()) return;
+        TileEntity te = event.getWorld().getBlockEntity(event.getPos());
+        if (!(te instanceof ChestTileEntity)) return;
+        if (event.getWorld().isClientSide()) {
+            ChestTileEntity chest = (ChestTileEntity) te;
+            Minecraft mc = Minecraft.getInstance();
+            PlayerInventory inv = mc.player.inventory;
+            ChestContainer cont = new ChestContainer(ContainerType.GENERIC_9x3, 0, inv, chest, 3);
+            mc.player.containerMenu = cont;
+            mc.setScreen(new ChestScreen(cont, inv, chest.getDisplayName()));
+        }
+        event.setCanceled(true);
+    }
+}

--- a/src/main/java/org/main/vision/actions/FullBrightHack.java
+++ b/src/main/java/org/main/vision/actions/FullBrightHack.java
@@ -1,0 +1,29 @@
+package org.main.vision.actions;
+
+import net.minecraft.potion.EffectInstance;
+import net.minecraft.potion.Effects;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+/** Gives the player night vision for a brighter world. */
+public class FullBrightHack extends ActionBase {
+    @SubscribeEvent
+    public void onTick(TickEvent.PlayerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) return;
+        PlayerEntity player = event.player;
+        if (isEnabled()) {
+            player.addEffect(new EffectInstance(Effects.NIGHT_VISION, 220, 0, false, false));
+        } else if (player.hasEffect(Effects.NIGHT_VISION)) {
+            player.removeEffect(Effects.NIGHT_VISION);
+        }
+    }
+
+    @Override
+    protected void onDisable() {
+        PlayerEntity player = net.minecraft.client.Minecraft.getInstance().player;
+        if (player != null) {
+            player.removeEffect(Effects.NIGHT_VISION);
+        }
+    }
+}

--- a/src/main/java/org/main/vision/config/UIState.java
+++ b/src/main/java/org/main/vision/config/UIState.java
@@ -16,6 +16,15 @@ public class UIState {
     public int miscBarY = 10;
     public boolean hacksExpanded = false;
 
+    // Additional bars for categorizing hacks
+    public int renderBarX = 120;
+    public int renderBarY = 10;
+    public boolean renderExpanded = false;
+
+    public int utilBarX = 230;
+    public int utilBarY = 10;
+    public boolean utilExpanded = false;
+
     /** Load state from disk. */
     public static UIState load() {
         if (Files.exists(FILE)) {

--- a/src/main/java/org/main/vision/mixin/MixinNetworkManager.java
+++ b/src/main/java/org/main/vision/mixin/MixinNetworkManager.java
@@ -1,0 +1,18 @@
+package org.main.vision.mixin;
+
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.IPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(NetworkManager.class)
+public class MixinNetworkManager {
+    @Inject(method = "send", at = @At("HEAD"), cancellable = true)
+    private void vision$send(IPacket<?> packet, CallbackInfo ci) {
+        if (org.main.vision.actions.BlinkHack.handleSend(packet)) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/vision.mixins.json
+++ b/src/main/resources/vision.mixins.json
@@ -4,10 +4,10 @@
   "package": "org.main.vision.mixin",
   "compatibilityLevel": "JAVA_8",
   "refmap": "vision.refmap.json",
-  "mixins": [
-  ],
+  "mixins": [],
   "client": [
-    "MixinFlowingFluidBlock"
+    "MixinFlowingFluidBlock",
+    "MixinNetworkManager"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary
- overhaul UI state to support multiple categories
- reorganize VisionMenuScreen with Movement, Render and Utility bars
- implement ChestInteract, FullBright and Blink hacks
- add NetworkManager mixin for Blink hack
- expose new keybinds and display hacks in overlay

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_685a0338cd1c832fbde04e24f9c8db83