### PR TITLE
Add configurable username feature

### DIFF
--- a/src/main/java/org/main/vision/UsernameOverride.java
+++ b/src/main/java/org/main/vision/UsernameOverride.java
@@ -5,6 +5,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.network.IPacket;
 import net.minecraft.network.login.client.CLoginStartPacket;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import org.main.vision.config.HackSettings;
+import org.main.vision.VisionClient;
 
 import java.lang.reflect.Field;
 
@@ -12,46 +14,39 @@ import java.lang.reflect.Field;
  * Replaces the player's username in packets with a custom value.
  */
 public class UsernameOverride {
-    private static String overrideName = "John Doe";
-
-    /** Set the spoofed name to use for connections. */
-    public static void setOverrideName(String name) {
-        if (name != null && !name.isEmpty()) {
-            overrideName = name;
-        }
-    }
-
-    /** @return the current spoofed name. */
-    public static String getOverrideName() {
-        return overrideName;
-    }
 
     /**
      * Modify outgoing packets to replace the player's GameProfile with the spoofed
      * username when starting a login.
      */
     public static void handleOutgoingPacket(IPacket<?> packet) {
-        if (packet instanceof CLoginStartPacket) {
-            try {
-                Field f = ObfuscationReflectionHelper.findField(CLoginStartPacket.class, "field_149305_a");
-                f.setAccessible(true);
-                GameProfile profile = (GameProfile) f.get(packet);
-                if (profile != null && !overrideName.equals(profile.getName())) {
-                    GameProfile replaced = new GameProfile(profile.getId(), overrideName);
-                    f.set(packet, replaced);
-                    // Also update the local player's session name so future packets use it
-                    Field userField = ObfuscationReflectionHelper.findField(Minecraft.class, "field_71449_j");
-                    userField.setAccessible(true);
-                    Object user = userField.get(Minecraft.getInstance());
-                    if (user != null) {
-                        @SuppressWarnings("unchecked")
-                        Field nameField = ObfuscationReflectionHelper.findField((Class<Object>) user.getClass(), "field_152554_a");
-                        nameField.setAccessible(true);
-                        nameField.set(user, overrideName);
-                    }
+        if (!(packet instanceof CLoginStartPacket)) return;
+
+        HackSettings cfg = VisionClient.getSettings();
+        if (!cfg.usernameOverrideEnabled) return;
+
+        String overrideName = cfg.customUsername;
+        if (overrideName == null || overrideName.isEmpty()) return;
+
+        try {
+            Field f = ObfuscationReflectionHelper.findField(CLoginStartPacket.class, "field_149305_a");
+            f.setAccessible(true);
+            GameProfile profile = (GameProfile) f.get(packet);
+            if (profile != null && !overrideName.equals(profile.getName())) {
+                GameProfile replaced = new GameProfile(profile.getId(), overrideName);
+                f.set(packet, replaced);
+                // Also update the local player's session name so future packets use it
+                Field userField = ObfuscationReflectionHelper.findField(Minecraft.class, "field_71449_j");
+                userField.setAccessible(true);
+                Object user = userField.get(Minecraft.getInstance());
+                if (user != null) {
+                    @SuppressWarnings("unchecked")
+                    Field nameField = ObfuscationReflectionHelper.findField((Class<Object>) user.getClass(), "field_152554_a");
+                    nameField.setAccessible(true);
+                    nameField.set(user, overrideName);
                 }
-            } catch (Exception ignored) {
             }
+        } catch (Exception ignored) {
         }
     }
 }

--- a/src/main/java/org/main/vision/UsernameSettingsScreen.java
+++ b/src/main/java/org/main/vision/UsernameSettingsScreen.java
@@ -1,0 +1,79 @@
+package org.main.vision;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.util.text.StringTextComponent;
+import org.main.vision.config.HackSettings;
+
+/** Screen for configuring the custom username feature. */
+public class UsernameSettingsScreen extends Screen {
+    private final Screen parent;
+    private TextFieldWidget field;
+    private PurpleButton toggleButton;
+    private PurpleButton applyButton;
+    private boolean enabled;
+    private boolean originalEnabled;
+    private String originalName;
+
+    public UsernameSettingsScreen(Screen parent) {
+        super(new StringTextComponent("Username Settings"));
+        this.parent = parent;
+    }
+
+    @Override
+    protected void init() {
+        HackSettings cfg = VisionClient.getSettings();
+        int centerX = this.width / 2;
+        int centerY = this.height / 2;
+        enabled = cfg.usernameOverrideEnabled;
+        originalEnabled = enabled;
+        originalName = cfg.customUsername;
+
+        toggleButton = addButton(new PurpleButton(centerX - 60, centerY - 40, 120, 20,
+                getToggleLabel(), b -> toggle()));
+
+        field = new TextFieldWidget(this.font, centerX - 60, centerY - 10, 120, 20, new StringTextComponent("Name"));
+        field.setMaxLength(32);
+        field.setValue(originalName);
+        addWidget(field);
+
+        applyButton = addButton(new PurpleButton(centerX - 60, centerY + 20, 120, 20,
+                new StringTextComponent("Apply"), b -> apply()));
+        addButton(new PurpleButton(centerX - 60, centerY + 50, 120, 20,
+                new StringTextComponent("Back"), b -> onClose()));
+    }
+
+    private StringTextComponent getToggleLabel() {
+        return new StringTextComponent((enabled ? "Disable" : "Enable") + " Custom Name");
+    }
+
+    private void toggle() {
+        enabled = !enabled;
+        toggleButton.setMessage(getToggleLabel());
+    }
+
+    @Override
+    public void render(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
+        this.renderBackground(ms);
+        drawCenteredString(ms, this.font, new StringTextComponent("Custom Name:"), this.width / 2, this.height / 2 - 25, 0xFFFFFF);
+        field.render(ms, mouseX, mouseY, partialTicks);
+        boolean changed = !field.getValue().equals(originalName) || enabled != originalEnabled;
+        applyButton.active = changed;
+        super.render(ms, mouseX, mouseY, partialTicks);
+    }
+
+    @Override
+    public void onClose() {
+        this.minecraft.setScreen(parent);
+    }
+
+    private void apply() {
+        HackSettings cfg = VisionClient.getSettings();
+        cfg.customUsername = field.getValue();
+        cfg.usernameOverrideEnabled = enabled;
+        originalName = cfg.customUsername;
+        originalEnabled = enabled;
+        VisionClient.saveSettings();
+    }
+}

--- a/src/main/java/org/main/vision/VisionMenuScreen.java
+++ b/src/main/java/org/main/vision/VisionMenuScreen.java
@@ -10,6 +10,8 @@ import org.main.vision.actions.SpeedHack;
 import org.main.vision.VisionClient;
 import org.main.vision.HackSettingsScreen;
 import org.main.vision.SpeedSettingsScreen;
+import org.main.vision.config.HackSettings;
+import org.main.vision.UsernameSettingsScreen;
 
 /** Simple in-game menu with a draggable bar and dropdown for hacks. */
 public class VisionMenuScreen extends Screen {
@@ -30,6 +32,8 @@ public class VisionMenuScreen extends Screen {
     private PurpleButton fullBrightButton;
     private PurpleButton chestButton;
     private PurpleButton blinkButton;
+    private PurpleButton usernameButton;
+    private PurpleButton usernameSettings;
     private static final int BUTTON_WIDTH = 100;
     private static final int BUTTON_HEIGHT = 20;
     private static final int BAR_WIDTH = BUTTON_WIDTH + 25;
@@ -111,8 +115,13 @@ public class VisionMenuScreen extends Screen {
         // Utility bar
         this.chestButton = addButton(new PurpleButton(state.utilBarX, state.utilBarY + 20 + (int)(20 * utilDropdownProgress) - 20, width, height,
                 getChestLabel(), b -> toggleChest()));
+        this.usernameButton = addButton(new PurpleButton(state.utilBarX, state.utilBarY + 40 + (int)(20 * utilDropdownProgress) - 20, width, height,
+                getUsernameLabel(), b -> toggleUsername()));
+        this.usernameSettings = addButton(new PurpleButton(state.utilBarX + width + 5, state.utilBarY + 40 + (int)(20 * utilDropdownProgress) - 20, 20, height,
+                new StringTextComponent("\u2699"), b -> openUsernameSettings()));
 
-        chestButton.visible = utilDropdownProgress > 0.05f;
+        chestButton.visible = usernameButton.visible = utilDropdownProgress > 0.05f;
+        usernameSettings.visible = utilDropdownProgress > 0.05f;
     }
 
     private void toggleSpeed() {
@@ -170,6 +179,13 @@ public class VisionMenuScreen extends Screen {
         state.save();
     }
 
+    private void toggleUsername() {
+        HackSettings cfg = VisionClient.getSettings();
+        cfg.usernameOverrideEnabled = !cfg.usernameOverrideEnabled;
+        usernameButton.setMessage(getUsernameLabel());
+        VisionClient.saveSettings();
+    }
+
     private void openSpeedSettings() {
         this.minecraft.setScreen(new SpeedSettingsScreen(this));
     }
@@ -196,6 +212,10 @@ public class VisionMenuScreen extends Screen {
 
     private void openXRaySettings() {
         this.minecraft.setScreen(new XRaySettingsScreen(this));
+    }
+
+    private void openUsernameSettings() {
+        this.minecraft.setScreen(new UsernameSettingsScreen(this));
     }
 
     private StringTextComponent getSpeedLabel() {
@@ -229,6 +249,11 @@ public class VisionMenuScreen extends Screen {
 
     private StringTextComponent getFullBrightLabel() {
         return new StringTextComponent((VisionClient.getFullBrightHack().isEnabled() ? "Disable" : "Enable") + " FullBright");
+    }
+
+    private StringTextComponent getUsernameLabel() {
+        boolean enabled = VisionClient.getSettings().usernameOverrideEnabled;
+        return new StringTextComponent((enabled ? "Disable" : "Enable") + " CustomName");
     }
 
     private StringTextComponent getChestLabel() {
@@ -310,6 +335,10 @@ public class VisionMenuScreen extends Screen {
             state.utilBarY = (int)mouseY - utilDragOffsetY;
             chestButton.x = state.utilBarX;
             chestButton.y = state.utilBarY + 20 + (int)(20 * utilDropdownProgress) - 20;
+            usernameButton.x = state.utilBarX;
+            usernameButton.y = state.utilBarY + 40 + (int)(20 * utilDropdownProgress) - 20;
+            usernameSettings.x = state.utilBarX + BUTTON_WIDTH + 5;
+            usernameSettings.y = usernameButton.y;
             return true;
         }
         return super.mouseDragged(mouseX, mouseY, button, dragX, dragY);
@@ -397,6 +426,10 @@ public class VisionMenuScreen extends Screen {
         xraySettings.y = xrayButton.y;
         chestButton.x = state.utilBarX;
         chestButton.y = state.utilBarY + 20 + (int)(20 * utilDropdownProgress) - 20;
+        usernameButton.x = state.utilBarX;
+        usernameButton.y = state.utilBarY + 40 + (int)(20 * utilDropdownProgress) - 20;
+        usernameSettings.x = state.utilBarX + BUTTON_WIDTH + 5;
+        usernameSettings.y = usernameButton.y;
 
         boolean vis = dropdownProgress > 0.05f;
         boolean visR = renderDropdownProgress > 0.05f;
@@ -405,7 +438,8 @@ public class VisionMenuScreen extends Screen {
         speedSettings.visible = jumpSettings.visible = flySettings.visible = jesusSettings.visible = noFallSettings.visible = vis;
         xrayButton.visible = fullBrightButton.visible = visR;
         xraySettings.visible = visR;
-        chestButton.visible = visU;
+        chestButton.visible = usernameButton.visible = visU;
+        usernameSettings.visible = visU;
         speedButton.setAlpha(dropdownProgress);
         jumpButton.setAlpha(dropdownProgress);
         flyButton.setAlpha(dropdownProgress);
@@ -421,6 +455,8 @@ public class VisionMenuScreen extends Screen {
         fullBrightButton.setAlpha(renderDropdownProgress);
         xraySettings.setAlpha(renderDropdownProgress);
         chestButton.setAlpha(utilDropdownProgress);
+        usernameButton.setAlpha(utilDropdownProgress);
+        usernameSettings.setAlpha(utilDropdownProgress);
 
         super.render(matrices, mouseX, mouseY, partialTicks);
     }

--- a/src/main/java/org/main/vision/config/HackSettings.java
+++ b/src/main/java/org/main/vision/config/HackSettings.java
@@ -30,6 +30,12 @@ public class HackSettings {
     /** List of block ids highlighted by XRayHack. */
     public java.util.List<String> xrayBlocks = new java.util.ArrayList<>();
 
+    /** Whether the username override is enabled. */
+    public boolean usernameOverrideEnabled = false;
+
+    /** The custom username to use when overriding. */
+    public String customUsername = "John Doe";
+
     /** Helper to check if a block should be highlighted. */
     public boolean isXrayTarget(net.minecraft.block.Block block) {
         if (block == null) return false;


### PR DESCRIPTION
## Summary
- allow overriding the player username in hack settings
- insert a menu toggle and settings screen for custom name
- apply override during login packet handling

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_685a23a0ed98832f859b84d661a3beef