### PR TITLE
Fix custom username spoof

### DIFF
--- a/src/main/java/org/main/vision/UsernameSettingsScreen.java
+++ b/src/main/java/org/main/vision/UsernameSettingsScreen.java
@@ -23,6 +23,8 @@ public class UsernameSettingsScreen extends Screen {
 
     @Override
     protected void init() {
+        this.buttons.clear();
+        this.children.clear();
         HackSettings cfg = VisionClient.getSettings();
         int centerX = this.width / 2;
         int centerY = this.height / 2;

--- a/src/main/java/org/main/vision/mixin/MixinNetworkManager.java
+++ b/src/main/java/org/main/vision/mixin/MixinNetworkManager.java
@@ -17,4 +17,9 @@ public class MixinNetworkManager {
         }
         org.main.vision.UsernameOverride.handleOutgoingPacket(packet);
     }
+
+    @Inject(method = "channelRead0", at = @At("HEAD"))
+    private void vision$channelRead0(io.netty.channel.ChannelHandlerContext ctx, IPacket<?> packet, CallbackInfo ci) {
+        org.main.vision.UsernameOverride.handleIncomingPacket(packet);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure login success packet and client session use the configured custom username
- call incoming packet handler from network mixin
- prevent duplicated widgets in username settings screen

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_685a274aef14832f874f4825b4d7ac36