### PR TITLE
Fix ArrowDeflectHack invalid entity disconnect

### DIFF
--- a/src/main/java/org/main/vision/actions/ArrowDeflectHack.java
+++ b/src/main/java/org/main/vision/actions/ArrowDeflectHack.java
@@ -40,7 +40,9 @@ public class ArrowDeflectHack extends ActionBase {
                 player.getBoundingBox().inflate(DEFLECT_RADIUS));
 
         for (AbstractArrowEntity arrow : arrows) {
-            if (!arrow.isAlive()) continue;
+            // Ignore arrows that the server hasn't acknowledged yet to
+            // avoid sending interaction packets for invalid entities.
+            if (!arrow.isAlive() || arrow.tickCount < 5 || arrow.getId() <= 0) continue;
             Vector3d motion = arrow.getDeltaMovement();
             Vector3d toPlayer = player.position().subtract(arrow.position());
             if (motion.dot(toPlayer) <= 0) continue; // Not heading toward the player


### PR DESCRIPTION
## Summary
- improve ArrowDeflectHack: skip unsynced arrows to avoid disconnect

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685b155571c0832fa8225c32c7c4b917