### PR TITLE
Improve bow aimbot targeting

### DIFF
--- a/src/main/java/org/main/vision/actions/BowAimbotHack.java
+++ b/src/main/java/org/main/vision/actions/BowAimbotHack.java
@@ -6,16 +6,21 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BowItem;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.math.EntityRayTraceResult;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 
 /**
- * Automatically adjusts aim for bow shots using simple prediction.
- * The improved version now predicts the target's future position based on
- * its current velocity and distance so that moving entities are hit more
- * consistently.
+ * Automatically adjusts aim for bow shots.
+ * <p>
+ * This version performs a predictive ray trace to select the entity the
+ * player is actually looking at and solves a simple intercept equation
+ * using the target's velocity and distance to estimate where the arrow
+ * should be aimed.  This results in far more consistent hits on moving
+ * targets and keeps the crosshair centered on the entity.
  */
 public class BowAimbotHack extends ActionBase {
     public enum Mode { PLAYERS, MOBS, BOTH }
@@ -41,9 +46,22 @@ public class BowAimbotHack extends ActionBase {
     }
 
     private LivingEntity findTarget(PlayerEntity player) {
+        double range = 50.0D;
+
+        // Try to ray trace the exact entity the player is looking at first
+        RayTraceResult result = player.pick(range, 1.0F, false);
+        if (result.getType() == RayTraceResult.Type.ENTITY) {
+            LivingEntity entity = (LivingEntity)((EntityRayTraceResult) result).getEntity();
+            if (entity != player && !entity.isInvisible() &&
+                    (mode == Mode.BOTH || (mode == Mode.PLAYERS && entity instanceof PlayerEntity) ||
+                            (mode == Mode.MOBS && !(entity instanceof PlayerEntity)))) {
+                return entity;
+            }
+        }
+
+        // Fallback to nearest entity in line of sight
         Vector3d eye = player.getEyePosition(1.0F);
         Vector3d look = player.getViewVector(1.0F);
-        double range = 50.0D;
         LivingEntity best = null;
         double bestDist = range;
 
@@ -58,7 +76,7 @@ public class BowAimbotHack extends ActionBase {
             double dist = toTarget.length();
             if (dist < bestDist) {
                 double dot = toTarget.normalize().dot(look);
-                if (dot > 0.99) {
+                if (dot > 0.98) {
                     bestDist = dist;
                     best = e;
                 }
@@ -68,25 +86,41 @@ public class BowAimbotHack extends ActionBase {
     }
 
     /**
-     * Estimate where the entity will be when an arrow reaches it.
-     * This uses a simple linear prediction based on the entity's
-     * current velocity and distance from the shooter.
+     * Estimate where the entity will be when an arrow reaches it by solving
+     * the intercept time for a constant speed projectile. The returned
+     * position represents the point the player should aim at.
      */
     private Vector3d predictPosition(LivingEntity target, PlayerEntity shooter) {
+        Vector3d shooterPos = shooter.getEyePosition(1.0F);
         Vector3d targetPos = target.getEyePosition(1.0F);
         Vector3d velocity = target.getDeltaMovement();
-        double distance = targetPos.distanceTo(shooter.getEyePosition(1.0F));
 
-        // Approximate arrow flight speed when fully charged.
+        // Approximate arrow flight speed when fully charged
         double arrowSpeed = 3.0D;
-        double time = distance / arrowSpeed;
+
+        Vector3d diff = targetPos.subtract(shooterPos);
+        double a = velocity.lengthSqr() - arrowSpeed * arrowSpeed;
+        double b = 2.0D * diff.dot(velocity);
+        double c = diff.lengthSqr();
+
+        double time;
+        double disc = b * b - 4.0D * a * c;
+        if (disc >= 0.0D && Math.abs(a) > 0.0001D) {
+            double sqrt = Math.sqrt(disc);
+            double t1 = (-b - sqrt) / (2.0D * a);
+            double t2 = (-b + sqrt) / (2.0D * a);
+            time = t1 > 0.0D ? t1 : t2;
+            if (time < 0.0D) time = diff.length() / arrowSpeed;
+        } else {
+            time = diff.length() / arrowSpeed;
+        }
 
         return targetPos.add(velocity.scale(time));
     }
 
     private void facePos(ClientPlayerEntity player, Vector3d pos) {
         double dx = pos.x - player.getX();
-        double dy = pos.y + 1.6 - player.getEyeY();
+        double dy = pos.y - player.getEyeY();
         double dz = pos.z - player.getZ();
         double dist = Math.sqrt(dx * dx + dz * dz);
         float yaw = (float)(Math.toDegrees(Math.atan2(dz, dx)) - 90.0F);


### PR DESCRIPTION
## Summary
- improve BowAimbot prediction logic
- raytrace entity under crosshair
- fix aim height offset

## Testing
- `./gradlew --no-daemon build`

------
https://chatgpt.com/codex/tasks/task_e_685b68379f44832fad2b71692ed006d8