### PR TITLE
Add RubberBander PvP desync hack

### DIFF
--- a/src/main/java/org/main/vision/VisionClient.java
+++ b/src/main/java/org/main/vision/VisionClient.java
@@ -22,6 +22,7 @@ import org.main.vision.actions.AutoSprintHack;
 import org.main.vision.actions.AutoRespawnHack;
 import org.main.vision.actions.BowAimbotHack;
 import org.main.vision.actions.HealthDisplayHack;
+import org.main.vision.actions.RubberBanderHack;
 import org.main.vision.config.HackSettings;
 
 /**
@@ -45,6 +46,7 @@ public class VisionClient {
     private static final AutoRespawnHack AUTORESPAWN_HACK = new AutoRespawnHack();
     private static final BowAimbotHack BOWAIMBOT_HACK = new BowAimbotHack();
     private static final HealthDisplayHack HEALTHDISPLAY_HACK = new HealthDisplayHack();
+    private static final RubberBanderHack RUBBERBANDER_HACK = new RubberBanderHack();
     private static HackSettings SETTINGS;
 
     static void init() {
@@ -116,6 +118,10 @@ public class VisionClient {
         return HEALTHDISPLAY_HACK;
     }
 
+    public static RubberBanderHack getRubberBanderHack() {
+        return RUBBERBANDER_HACK;
+    }
+
 
     public static HackSettings getSettings() {
         return SETTINGS;
@@ -177,6 +183,9 @@ public class VisionClient {
         }
         if (event.getKey() == VisionKeybind.healthDisplayKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
             HEALTHDISPLAY_HACK.toggle();
+        }
+        if (event.getKey() == VisionKeybind.rubberBanderKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
+            RUBBERBANDER_HACK.toggle();
         }
         if (event.getKey() == VisionKeybind.menuKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS) {
             Minecraft.getInstance().setScreen(new VisionMenuScreen());

--- a/src/main/java/org/main/vision/VisionKeybind.java
+++ b/src/main/java/org/main/vision/VisionKeybind.java
@@ -24,6 +24,7 @@ public class VisionKeybind {
     public static KeyBinding autoRespawnKey;
     public static KeyBinding bowAimbotKey;
     public static KeyBinding healthDisplayKey;
+    public static KeyBinding rubberBanderKey;
     public static KeyBinding menuKey;
 
     static void register() {
@@ -43,6 +44,7 @@ public class VisionKeybind {
         autoRespawnKey = new KeyBinding("key.vision.autorespawn", GLFW.GLFW_KEY_R, "key.categories.vision");
         bowAimbotKey = new KeyBinding("key.vision.bowaimbot", GLFW.GLFW_KEY_X, "key.categories.vision");
         healthDisplayKey = new KeyBinding("key.vision.healthdisplay", GLFW.GLFW_KEY_U, "key.categories.vision");
+        rubberBanderKey = new KeyBinding("key.vision.rubberbander", GLFW.GLFW_KEY_Y, "key.categories.vision");
         menuKey = new KeyBinding("key.vision.menu", GLFW.GLFW_KEY_BACKSLASH, "key.categories.vision");
         ClientRegistry.registerKeyBinding(speedKey);
         ClientRegistry.registerKeyBinding(jumpKey);
@@ -60,6 +62,7 @@ public class VisionKeybind {
         ClientRegistry.registerKeyBinding(autoRespawnKey);
         ClientRegistry.registerKeyBinding(bowAimbotKey);
         ClientRegistry.registerKeyBinding(healthDisplayKey);
+        ClientRegistry.registerKeyBinding(rubberBanderKey);
         ClientRegistry.registerKeyBinding(menuKey);
     }
 }

--- a/src/main/java/org/main/vision/VisionMenuScreen.java
+++ b/src/main/java/org/main/vision/VisionMenuScreen.java
@@ -51,6 +51,7 @@ public class VisionMenuScreen extends Screen {
         addEntry(() -> getAutoRespawnLabel(), this::toggleAutoRespawn, null);
         addEntry(() -> getBowAimbotLabel(), this::toggleBowAimbot, null);
         addEntry(() -> getHealthDisplayLabel(), this::toggleHealthDisplay, null);
+        addEntry(() -> getRubberBanderLabel(), this::toggleRubberBander, null);
         layoutButtons();
     }
 
@@ -129,6 +130,7 @@ public class VisionMenuScreen extends Screen {
     private void toggleAutoRespawn() { VisionClient.getAutoRespawnHack().toggle(); }
     private void toggleBowAimbot() { VisionClient.getBowAimbotHack().toggle(); }
     private void toggleHealthDisplay() { VisionClient.getHealthDisplayHack().toggle(); }
+    private void toggleRubberBander() { VisionClient.getRubberBanderHack().toggle(); }
 
     // Settings open methods
     private void openSpeedSettings() { this.minecraft.setScreen(new SpeedSettingsScreen(this)); }
@@ -159,4 +161,5 @@ public class VisionMenuScreen extends Screen {
     private StringTextComponent getAutoRespawnLabel() { return new StringTextComponent((VisionClient.getAutoRespawnHack().isEnabled() ? "Disable" : "Enable") + " AutoRespawn"); }
     private StringTextComponent getBowAimbotLabel() { return new StringTextComponent((VisionClient.getBowAimbotHack().isEnabled() ? "Disable" : "Enable") + " BowAimbot"); }
     private StringTextComponent getHealthDisplayLabel() { return new StringTextComponent((VisionClient.getHealthDisplayHack().isEnabled() ? "Disable" : "Enable") + " HealthDisplay"); }
+    private StringTextComponent getRubberBanderLabel() { return new StringTextComponent((VisionClient.getRubberBanderHack().isEnabled() ? "Disable" : "Enable") + " RubberBander"); }
 }

--- a/src/main/java/org/main/vision/VisionOverlay.java
+++ b/src/main/java/org/main/vision/VisionOverlay.java
@@ -114,5 +114,11 @@ public class VisionOverlay {
             mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
             y += mc.font.lineHeight;
         }
+        if (VisionClient.getRubberBanderHack().isEnabled()) {
+            String text = "RubberBander";
+            int w = mc.font.width(text);
+            mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
+            y += mc.font.lineHeight;
+        }
     }
 }

--- a/src/main/java/org/main/vision/actions/RubberBanderHack.java
+++ b/src/main/java/org/main/vision/actions/RubberBanderHack.java
@@ -1,0 +1,95 @@
+package org.main.vision.actions;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.player.ClientPlayerEntity;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.IPacket;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.play.client.CPlayerPacket;
+import net.minecraft.network.play.client.CUseEntityPacket;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import java.util.*;
+
+/**
+ * Delays and reorders outgoing PvP packets to create mild desync effects.
+ */
+public class RubberBanderHack extends ActionBase {
+    private static final int DELAY_TICKS = 2;
+
+    private static class Queued {
+        final IPacket<?> packet;
+        final int sendTick;
+        Queued(IPacket<?> p, int t) { this.packet = p; this.sendTick = t; }
+    }
+
+    private final Queue<Queued> queue = new LinkedList<>();
+
+    public static boolean handleSend(IPacket<?> packet) {
+        RubberBanderHack hack = org.main.vision.VisionClient.getRubberBanderHack();
+        if (hack.isEnabled() && hack.shouldQueue(packet)) {
+            Minecraft mc = Minecraft.getInstance();
+            ClientWorld world = mc.level;
+            if (world != null) {
+                int tick = (int) world.getGameTime() + DELAY_TICKS;
+                hack.queue.add(new Queued(packet, tick));
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean shouldQueue(IPacket<?> packet) {
+        if (!(packet instanceof CPlayerPacket || packet instanceof CUseEntityPacket)) return false;
+        Minecraft mc = Minecraft.getInstance();
+        ClientPlayerEntity player = mc.player;
+        ClientWorld world = mc.level;
+        if (player == null || world == null) return false;
+        for (PlayerEntity p : world.players()) {
+            if (p != player && p.distanceToSqr(player) < 9.0D) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected void onDisable() {
+        flushAll();
+    }
+
+    @SubscribeEvent
+    public void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) return;
+        flushReady();
+    }
+
+    private void flushReady() {
+        Minecraft mc = Minecraft.getInstance();
+        ClientWorld world = mc.level;
+        if (world == null || mc.getConnection() == null) return;
+        int tick = (int) world.getGameTime();
+        if (queue.isEmpty()) return;
+        List<IPacket<?>> send = new ArrayList<>();
+        while (!queue.isEmpty() && queue.peek().sendTick <= tick) {
+            send.add(queue.poll().packet);
+        }
+        if (send.isEmpty()) return;
+        Collections.reverse(send);
+        NetworkManager nm = mc.getConnection().getConnection();
+        for (IPacket<?> p : send) {
+            nm.send(p);
+        }
+    }
+
+    private void flushAll() {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.getConnection() == null) return;
+        NetworkManager nm = mc.getConnection().getConnection();
+        while (!queue.isEmpty()) {
+            nm.send(queue.poll().packet);
+        }
+    }
+}

--- a/src/main/java/org/main/vision/mixin/MixinClientPlayNetHandler.java
+++ b/src/main/java/org/main/vision/mixin/MixinClientPlayNetHandler.java
@@ -1,6 +1,7 @@
 package org.main.vision.mixin;
 
 import net.minecraft.client.network.play.ClientPlayNetHandler;
+import net.minecraft.network.IPacket;
 import net.minecraft.network.play.server.SEntityVelocityPacket;
 import net.minecraft.network.play.server.SExplosionPacket;
 import net.minecraft.client.Minecraft;
@@ -31,6 +32,17 @@ public class MixinClientPlayNetHandler {
             if (mc.player != null) {
                 mc.player.setDeltaMovement(0.0D, 0.0D, 0.0D);
             }
+        }
+    }
+
+    @Inject(method = "send", at = @At("HEAD"), cancellable = true)
+    private void vision$onSend(IPacket<?> packet, CallbackInfo ci) {
+        if (org.main.vision.actions.BlinkHack.handleSend(packet)) {
+            ci.cancel();
+            return;
+        }
+        if (org.main.vision.actions.RubberBanderHack.handleSend(packet)) {
+            ci.cancel();
         }
     }
 }

--- a/src/main/java/org/main/vision/mixin/MixinNetworkManager.java
+++ b/src/main/java/org/main/vision/mixin/MixinNetworkManager.java
@@ -1,0 +1,25 @@
+package org.main.vision.mixin;
+
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.IPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Intercepts outgoing packets for Blink and RubberBander hacks.
+ */
+@Mixin(NetworkManager.class)
+public class MixinNetworkManager {
+    @Inject(method = "send", at = @At("HEAD"), cancellable = true)
+    private void vision$onSend(IPacket<?> packet, CallbackInfo ci) {
+        if (org.main.vision.actions.BlinkHack.handleSend(packet)) {
+            ci.cancel();
+            return;
+        }
+        if (org.main.vision.actions.RubberBanderHack.handleSend(packet)) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/vision.mixins.json
+++ b/src/main/resources/vision.mixins.json
@@ -7,7 +7,8 @@
   "mixins": [],
   "client": [
     "MixinFlowingFluidBlock",
-    "MixinClientPlayNetHandler"
+    "MixinClientPlayNetHandler",
+    "MixinNetworkManager"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary
- add RubberBander hack for delaying PvP packets
- intercept outgoing packets via new NetworkManager mixin
- expose keybind and menu options for RubberBander
- display RubberBander state in overlay

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685c4c93039c832fad4b36e941a3408e