### PR TITLE
Add SpoofName alias feature

### DIFF
--- a/src/main/java/org/main/vision/SpoofNameSettingsScreen.java
+++ b/src/main/java/org/main/vision/SpoofNameSettingsScreen.java
@@ -1,0 +1,79 @@
+package org.main.vision;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.client.gui.widget.button.CheckboxButton;
+import net.minecraft.util.text.StringTextComponent;
+import org.main.vision.config.HackSettings;
+
+/** Screen for configuring the SpoofName hack. */
+public class SpoofNameSettingsScreen extends Screen {
+    private final Screen parent;
+    private TextFieldWidget aliasField;
+    private CheckboxButton incomingBox;
+    private CheckboxButton outgoingBox;
+    private PurpleButton applyButton;
+    private String originalAlias;
+    private boolean originalIncoming;
+    private boolean originalOutgoing;
+
+    public SpoofNameSettingsScreen(Screen parent) {
+        super(new StringTextComponent("SpoofName Settings"));
+        this.parent = parent;
+    }
+
+    @Override
+    protected void init() {
+        HackSettings cfg = VisionClient.getSettings();
+        originalAlias = cfg.spoofName;
+        originalIncoming = cfg.spoofIncoming;
+        originalOutgoing = cfg.spoofOutgoing;
+
+        int centerX = this.width / 2;
+        int y = this.height / 2 - 30;
+        aliasField = new TextFieldWidget(this.font, centerX - 80, y, 160, 20, new StringTextComponent("Alias"));
+        aliasField.setMaxLength(32);
+        aliasField.setValue(originalAlias);
+        addWidget(aliasField);
+
+        y += 25;
+        incomingBox = new CheckboxButton(centerX - 80, y, 160, 20, new StringTextComponent("Spoof Incoming"), originalIncoming);
+        addButton(incomingBox);
+        y += 25;
+        outgoingBox = new CheckboxButton(centerX - 80, y, 160, 20, new StringTextComponent("Spoof Outgoing"), originalOutgoing);
+        addButton(outgoingBox);
+
+        y += 30;
+        applyButton = addButton(new PurpleButton(centerX - 60, y, 120, 20, new StringTextComponent("Apply"), b -> apply()));
+        y += 24;
+        addButton(new PurpleButton(centerX - 60, y, 120, 20, new StringTextComponent("Back"), b -> onClose()));
+    }
+
+    @Override
+    public void render(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
+        this.renderBackground(ms);
+        drawCenteredString(ms, this.font, new StringTextComponent("Alias:"), this.width / 2, this.height / 2 - 45, 0xFFFFFF);
+        super.render(ms, mouseX, mouseY, partialTicks);
+        aliasField.render(ms, mouseX, mouseY, partialTicks);
+        boolean changed = !aliasField.getValue().equals(originalAlias) || incomingBox.selected() != originalIncoming || outgoingBox.selected() != originalOutgoing;
+        applyButton.active = changed;
+    }
+
+    @Override
+    public void onClose() {
+        this.minecraft.setScreen(parent);
+    }
+
+    private void apply() {
+        HackSettings cfg = VisionClient.getSettings();
+        cfg.spoofName = aliasField.getValue().trim();
+        cfg.spoofIncoming = incomingBox.selected();
+        cfg.spoofOutgoing = outgoingBox.selected();
+        VisionClient.saveSettings();
+        originalAlias = cfg.spoofName;
+        originalIncoming = cfg.spoofIncoming;
+        originalOutgoing = cfg.spoofOutgoing;
+        applyButton.active = false;
+    }
+}

--- a/src/main/java/org/main/vision/VisionClient.java
+++ b/src/main/java/org/main/vision/VisionClient.java
@@ -23,6 +23,7 @@ import org.main.vision.actions.AutoRespawnHack;
 import org.main.vision.actions.BowAimbotHack;
 import org.main.vision.actions.HealthDisplayHack;
 import org.main.vision.actions.RubberBanderHack;
+import org.main.vision.actions.SpoofNameHack;
 import org.main.vision.config.HackSettings;
 
 /**
@@ -47,6 +48,7 @@ public class VisionClient {
     private static final BowAimbotHack BOWAIMBOT_HACK = new BowAimbotHack();
     private static final HealthDisplayHack HEALTHDISPLAY_HACK = new HealthDisplayHack();
     private static final RubberBanderHack RUBBERBANDER_HACK = new RubberBanderHack();
+    private static final SpoofNameHack SPOOFNAME_HACK = new SpoofNameHack();
     private static HackSettings SETTINGS;
 
     static void init() {
@@ -122,6 +124,10 @@ public class VisionClient {
         return RUBBERBANDER_HACK;
     }
 
+    public static SpoofNameHack getSpoofNameHack() {
+        return SPOOFNAME_HACK;
+    }
+
 
     public static HackSettings getSettings() {
         return SETTINGS;
@@ -186,6 +192,9 @@ public class VisionClient {
         }
         if (event.getKey() == VisionKeybind.rubberBanderKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
             RUBBERBANDER_HACK.toggle();
+        }
+        if (event.getKey() == VisionKeybind.spoofNameKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
+            SPOOFNAME_HACK.toggle();
         }
         if (event.getKey() == VisionKeybind.menuKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS) {
             Minecraft.getInstance().setScreen(new VisionMenuScreen());

--- a/src/main/java/org/main/vision/VisionKeybind.java
+++ b/src/main/java/org/main/vision/VisionKeybind.java
@@ -25,6 +25,7 @@ public class VisionKeybind {
     public static KeyBinding bowAimbotKey;
     public static KeyBinding healthDisplayKey;
     public static KeyBinding rubberBanderKey;
+    public static KeyBinding spoofNameKey;
     public static KeyBinding menuKey;
 
     static void register() {
@@ -45,6 +46,7 @@ public class VisionKeybind {
         bowAimbotKey = new KeyBinding("key.vision.bowaimbot", GLFW.GLFW_KEY_X, "key.categories.vision");
         healthDisplayKey = new KeyBinding("key.vision.healthdisplay", GLFW.GLFW_KEY_U, "key.categories.vision");
         rubberBanderKey = new KeyBinding("key.vision.rubberbander", GLFW.GLFW_KEY_Y, "key.categories.vision");
+        spoofNameKey = new KeyBinding("key.vision.spoofname", GLFW.GLFW_KEY_N, "key.categories.vision");
         menuKey = new KeyBinding("key.vision.menu", GLFW.GLFW_KEY_BACKSLASH, "key.categories.vision");
         ClientRegistry.registerKeyBinding(speedKey);
         ClientRegistry.registerKeyBinding(jumpKey);
@@ -63,6 +65,7 @@ public class VisionKeybind {
         ClientRegistry.registerKeyBinding(bowAimbotKey);
         ClientRegistry.registerKeyBinding(healthDisplayKey);
         ClientRegistry.registerKeyBinding(rubberBanderKey);
+        ClientRegistry.registerKeyBinding(spoofNameKey);
         ClientRegistry.registerKeyBinding(menuKey);
     }
 }

--- a/src/main/java/org/main/vision/VisionMenuScreen.java
+++ b/src/main/java/org/main/vision/VisionMenuScreen.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.util.text.StringTextComponent;
+import org.main.vision.SpoofNameSettingsScreen;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,6 +53,7 @@ public class VisionMenuScreen extends Screen {
         addEntry(() -> getBowAimbotLabel(), this::toggleBowAimbot, null);
         addEntry(() -> getHealthDisplayLabel(), this::toggleHealthDisplay, null);
         addEntry(() -> getRubberBanderLabel(), this::toggleRubberBander, null);
+        addEntry(() -> getSpoofNameLabel(), this::toggleSpoofName, this::openSpoofNameSettings);
         layoutButtons();
     }
 
@@ -131,6 +133,7 @@ public class VisionMenuScreen extends Screen {
     private void toggleBowAimbot() { VisionClient.getBowAimbotHack().toggle(); }
     private void toggleHealthDisplay() { VisionClient.getHealthDisplayHack().toggle(); }
     private void toggleRubberBander() { VisionClient.getRubberBanderHack().toggle(); }
+    private void toggleSpoofName() { VisionClient.getSpoofNameHack().toggle(); }
 
     // Settings open methods
     private void openSpeedSettings() { this.minecraft.setScreen(new SpeedSettingsScreen(this)); }
@@ -143,6 +146,7 @@ public class VisionMenuScreen extends Screen {
     private void openNoFallSettings() { this.minecraft.setScreen(new HackSettingsScreen(this, "Threshold", () -> VisionClient.getSettings().noFallThreshold,
             v -> { VisionClient.getSettings().noFallThreshold = v; }, VisionClient::saveSettings, 2.0D)); }
     private void openXRaySettings() { this.minecraft.setScreen(new XRaySettingsScreen(this)); }
+    private void openSpoofNameSettings() { this.minecraft.setScreen(new SpoofNameSettingsScreen(this)); }
 
     // Label helpers
     private StringTextComponent getSpeedLabel() { return new StringTextComponent((VisionClient.getSpeedHack().isEnabled() ? "Disable" : "Enable") + " Speed"); }
@@ -162,4 +166,5 @@ public class VisionMenuScreen extends Screen {
     private StringTextComponent getBowAimbotLabel() { return new StringTextComponent((VisionClient.getBowAimbotHack().isEnabled() ? "Disable" : "Enable") + " BowAimbot"); }
     private StringTextComponent getHealthDisplayLabel() { return new StringTextComponent((VisionClient.getHealthDisplayHack().isEnabled() ? "Disable" : "Enable") + " HealthDisplay"); }
     private StringTextComponent getRubberBanderLabel() { return new StringTextComponent((VisionClient.getRubberBanderHack().isEnabled() ? "Disable" : "Enable") + " RubberBander"); }
+    private StringTextComponent getSpoofNameLabel() { return new StringTextComponent((VisionClient.getSpoofNameHack().isEnabled() ? "Disable" : "Enable") + " SpoofName"); }
 }

--- a/src/main/java/org/main/vision/actions/SpoofNameHack.java
+++ b/src/main/java/org/main/vision/actions/SpoofNameHack.java
@@ -1,0 +1,76 @@
+package org.main.vision.actions;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.player.ClientPlayerEntity;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraftforge.client.event.ClientChatEvent;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
+import org.main.vision.VisionClient;
+import org.main.vision.config.HackSettings;
+
+/**
+ * Replaces the player's name in chat with a user defined alias.
+ */
+public class SpoofNameHack extends ActionBase {
+    private String actualName;
+
+    @Override
+    protected void onEnable() {
+        captureName();
+        applyAlias();
+    }
+
+    @Override
+    protected void onDisable() {
+        ClientPlayerEntity player = Minecraft.getInstance().player;
+        if (player != null) {
+            player.setCustomName(null);
+        }
+    }
+
+    private void captureName() {
+        ClientPlayerEntity player = Minecraft.getInstance().player;
+        if (player != null) {
+            actualName = player.getGameProfile().getName();
+        }
+    }
+
+    private void applyAlias() {
+        ClientPlayerEntity player = Minecraft.getInstance().player;
+        HackSettings cfg = VisionClient.getSettings();
+        if (player != null && cfg.spoofName != null && !cfg.spoofName.isEmpty()) {
+            player.setCustomName(new StringTextComponent(cfg.spoofName));
+        }
+    }
+
+    @SubscribeEvent
+    public void onLogin(ClientPlayerNetworkEvent.LoggedInEvent event) {
+        if (!isEnabled()) return;
+        captureName();
+        applyAlias();
+    }
+
+    @SubscribeEvent
+    public void onChatReceive(ClientChatReceivedEvent event) {
+        if (!isEnabled()) return;
+        HackSettings cfg = VisionClient.getSettings();
+        if (!cfg.spoofIncoming) return;
+        String alias = cfg.spoofName;
+        if (alias == null || alias.isEmpty() || actualName == null) return;
+        String msg = event.getMessage().getString().replace(actualName, alias);
+        event.setMessage(new StringTextComponent(msg));
+    }
+
+    @SubscribeEvent
+    public void onChatSend(ClientChatEvent event) {
+        if (!isEnabled()) return;
+        HackSettings cfg = VisionClient.getSettings();
+        if (!cfg.spoofOutgoing) return;
+        String alias = cfg.spoofName;
+        if (alias == null || alias.isEmpty() || actualName == null) return;
+        String msg = event.getMessage().replace(actualName, alias);
+        event.setMessage(msg);
+    }
+}

--- a/src/main/java/org/main/vision/config/HackSettings.java
+++ b/src/main/java/org/main/vision/config/HackSettings.java
@@ -30,6 +30,13 @@ public class HackSettings {
     /** List of block ids highlighted by XRayHack. */
     public java.util.List<String> xrayBlocks = new java.util.ArrayList<>();
 
+    /** Alias used by the SpoofName hack. */
+    public String spoofName = "";
+    /** Whether incoming chat should use the alias. */
+    public boolean spoofIncoming = true;
+    /** Whether outgoing chat should use the alias. */
+    public boolean spoofOutgoing = true;
+
 
     /** Helper to check if a block should be highlighted. */
     public boolean isXrayTarget(net.minecraft.block.Block block) {


### PR DESCRIPTION
## Summary
- enable alias spoofing for username with `SpoofNameHack`
- allow users to configure alias text and toggles for incoming/outgoing chat
- register keybind and menu entry for SpoofName

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685c56c13e0c832fb1e1b884f89b248e