### PR TITLE
Improve username spoof feature

### DIFF
--- a/src/main/java/org/main/vision/SpoofNameSettingsScreen.java
+++ b/src/main/java/org/main/vision/SpoofNameSettingsScreen.java
@@ -71,6 +71,7 @@ public class SpoofNameSettingsScreen extends Screen {
         cfg.spoofIncoming = incomingBox.selected();
         cfg.spoofOutgoing = outgoingBox.selected();
         VisionClient.saveSettings();
+        VisionClient.getSpoofNameHack().refreshAlias();
         originalAlias = cfg.spoofName;
         originalIncoming = cfg.spoofIncoming;
         originalOutgoing = cfg.spoofOutgoing;

--- a/src/main/java/org/main/vision/actions/SpoofNameHack.java
+++ b/src/main/java/org/main/vision/actions/SpoofNameHack.java
@@ -2,11 +2,12 @@ package org.main.vision.actions;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.player.ClientPlayerEntity;
+import net.minecraft.client.network.play.NetworkPlayerInfo;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraftforge.client.event.ClientChatEvent;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.main.vision.VisionClient;
 import org.main.vision.config.HackSettings;
 
@@ -20,6 +21,7 @@ public class SpoofNameHack extends ActionBase {
     protected void onEnable() {
         captureName();
         applyAlias();
+        applyTabListAlias();
     }
 
     @Override
@@ -27,6 +29,7 @@ public class SpoofNameHack extends ActionBase {
         ClientPlayerEntity player = Minecraft.getInstance().player;
         if (player != null) {
             player.setCustomName(null);
+            clearTabListAlias();
         }
     }
 
@@ -42,6 +45,39 @@ public class SpoofNameHack extends ActionBase {
         HackSettings cfg = VisionClient.getSettings();
         if (player != null && cfg.spoofName != null && !cfg.spoofName.isEmpty()) {
             player.setCustomName(new StringTextComponent(cfg.spoofName));
+            applyTabListAlias();
+        }
+    }
+
+    /** Update the player's name in the tab list. */
+    private void applyTabListAlias() {
+        ClientPlayerEntity player = Minecraft.getInstance().player;
+        HackSettings cfg = VisionClient.getSettings();
+        if (player == null || Minecraft.getInstance().getConnection() == null) return;
+        NetworkPlayerInfo info = Minecraft.getInstance().getConnection().getPlayerInfo(player.getUUID());
+        if (info != null) {
+            if (cfg.spoofName != null && !cfg.spoofName.isEmpty()) {
+                info.setTabListDisplayName(new StringTextComponent(cfg.spoofName));
+            } else {
+                info.setTabListDisplayName(null);
+            }
+        }
+    }
+
+    /** Remove any alias from the tab list. */
+    private void clearTabListAlias() {
+        ClientPlayerEntity player = Minecraft.getInstance().player;
+        if (player == null || Minecraft.getInstance().getConnection() == null) return;
+        NetworkPlayerInfo info = Minecraft.getInstance().getConnection().getPlayerInfo(player.getUUID());
+        if (info != null) {
+            info.setTabListDisplayName(null);
+        }
+    }
+
+    /** Reapply the alias when settings are changed. */
+    public void refreshAlias() {
+        if (isEnabled()) {
+            applyAlias();
         }
     }
 


### PR DESCRIPTION
## Summary
- expand SpoofName hack to replace the tab list name as well as chat
- refresh alias when settings are saved

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685c5eeb6500832f96a4047793afbb4a