### PR TITLE
Add packet-level alias spoofing

### DIFF
--- a/src/main/java/org/main/vision/mixin/MixinClientPlayNetHandler.java
+++ b/src/main/java/org/main/vision/mixin/MixinClientPlayNetHandler.java
@@ -44,5 +44,6 @@ public class MixinClientPlayNetHandler {
         if (org.main.vision.actions.RubberBanderHack.handleSend(packet)) {
             ci.cancel();
         }
+        org.main.vision.actions.SpoofNameHack.handleOutgoing(packet);
     }
 }

--- a/src/main/java/org/main/vision/mixin/MixinNetworkManager.java
+++ b/src/main/java/org/main/vision/mixin/MixinNetworkManager.java
@@ -6,9 +6,10 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import io.netty.channel.ChannelHandlerContext;
 
 /**
- * Intercepts outgoing packets for Blink and RubberBander hacks.
+ * Intercepts network packets for various hacks.
  */
 @Mixin(NetworkManager.class)
 public class MixinNetworkManager {
@@ -21,5 +22,11 @@ public class MixinNetworkManager {
         if (org.main.vision.actions.RubberBanderHack.handleSend(packet)) {
             ci.cancel();
         }
+        org.main.vision.actions.SpoofNameHack.handleOutgoing(packet);
+    }
+
+    @Inject(method = "channelRead0", at = @At("HEAD"))
+    private void vision$onReceive(ChannelHandlerContext ctx, IPacket<?> packet, CallbackInfo ci) {
+        org.main.vision.actions.SpoofNameHack.handleIncoming(packet);
     }
 }

--- a/src/main/java/org/main/vision/util/PacketStringReplacer.java
+++ b/src/main/java/org/main/vision/util/PacketStringReplacer.java
@@ -1,0 +1,80 @@
+package org.main.vision.util;
+
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/** Utility that recursively replaces occurrences of a string inside packet objects. */
+public class PacketStringReplacer {
+    public static void replaceStrings(Object obj, String from, String to) {
+        replaceStrings(obj, from, to, new IdentityHashMap<>());
+    }
+
+    private static void replaceStrings(Object obj, String from, String to, Map<Object, Boolean> visited) {
+        if (obj == null || from == null || from.isEmpty() || to == null || visited.containsKey(obj)) {
+            return;
+        }
+        visited.put(obj, Boolean.TRUE);
+
+        Class<?> cls = obj.getClass();
+        if (obj instanceof String) {
+            // nothing
+            return;
+        } else if (obj instanceof ITextComponent) {
+            ITextComponent comp = (ITextComponent) obj;
+            String txt = comp.getString();
+            if (txt.contains(from)) {
+                if (comp instanceof StringTextComponent) {
+                    try {
+                        Field f = StringTextComponent.class.getDeclaredField("text");
+                        f.setAccessible(true);
+                        f.set(comp, txt.replace(from, to));
+                    } catch (Exception ignore) {}
+                }
+            }
+        } else if (cls.isArray()) {
+            int len = Array.getLength(obj);
+            for (int i = 0; i < len; i++) {
+                Object item = Array.get(obj, i);
+                if (item instanceof String) {
+                    String s = (String) item;
+                    if (s.contains(from)) Array.set(obj, i, s.replace(from, to));
+                } else {
+                    replaceStrings(item, from, to, visited);
+                }
+            }
+            return;
+        } else if (obj instanceof Iterable) {
+            for (Object item : (Iterable<?>) obj) {
+                replaceStrings(item, from, to, visited);
+            }
+            return;
+        } else if (obj instanceof Map) {
+            for (Object val : ((Map<?, ?>) obj).values()) {
+                replaceStrings(val, from, to, visited);
+            }
+            return;
+        }
+
+        for (Field f : cls.getDeclaredFields()) {
+            if ((f.getModifiers() & Modifier.STATIC) != 0) continue;
+            f.setAccessible(true);
+            try {
+                Object value = f.get(obj);
+                if (value instanceof String) {
+                    String s = (String) value;
+                    if (s != null && s.contains(from)) {
+                        f.set(obj, s.replace(from, to));
+                    }
+                } else {
+                    replaceStrings(value, from, to, visited);
+                }
+            } catch (IllegalAccessException ignored) {}
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- rewrite name spoofing to work directly on packets
- introduce `PacketStringReplacer` utility for recursive string replacements
- update mixins to process incoming and outgoing packets

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_685c673bb588832fbc535b4298e2f4c3