### PR TITLE
Implement packet-level alias spoofing

### DIFF
--- a/src/main/java/org/main/vision/mixin/MixinClientPlayNetHandler.java
+++ b/src/main/java/org/main/vision/mixin/MixinClientPlayNetHandler.java
@@ -37,6 +37,7 @@ public class MixinClientPlayNetHandler {
 
     @Inject(method = "send", at = @At("HEAD"), cancellable = true)
     private void vision$onSend(IPacket<?> packet, CallbackInfo ci) {
+        org.main.vision.actions.SpoofNameHack.handleOutgoing(packet);
         if (org.main.vision.actions.BlinkHack.handleSend(packet)) {
             ci.cancel();
             return;

--- a/src/main/java/org/main/vision/mixin/MixinNetworkManager.java
+++ b/src/main/java/org/main/vision/mixin/MixinNetworkManager.java
@@ -6,6 +6,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import io.netty.channel.ChannelHandlerContext;
 
 /**
  * Intercepts outgoing packets for Blink and RubberBander hacks.
@@ -14,6 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class MixinNetworkManager {
     @Inject(method = "send", at = @At("HEAD"), cancellable = true)
     private void vision$onSend(IPacket<?> packet, CallbackInfo ci) {
+        org.main.vision.actions.SpoofNameHack.handleOutgoing(packet);
         if (org.main.vision.actions.BlinkHack.handleSend(packet)) {
             ci.cancel();
             return;
@@ -21,5 +23,10 @@ public class MixinNetworkManager {
         if (org.main.vision.actions.RubberBanderHack.handleSend(packet)) {
             ci.cancel();
         }
+    }
+
+    @Inject(method = "channelRead0", at = @At("HEAD"))
+    private void vision$onReceive(ChannelHandlerContext ctx, IPacket<?> packet, CallbackInfo ci) {
+        org.main.vision.actions.SpoofNameHack.handleIncoming(packet);
     }
 }


### PR DESCRIPTION
## Summary
- overhaul SpoofName hack to modify network packets instead of chat events
- traverse packets recursively to replace the player's name
- call the spoof logic from outgoing/incoming packet mixins

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685c69c67f18832f9e725583298dcbc1