### PR TITLE
Fix crashes and refine name spoof

### DIFF
--- a/src/main/java/org/main/vision/actions/BlinkHack.java
+++ b/src/main/java/org/main/vision/actions/BlinkHack.java
@@ -64,6 +64,10 @@ public class BlinkHack extends ActionBase {
     /** Send all queued packets to the server. */
     private void flushQueue() {
         if (queue.isEmpty()) return;
+        if (Minecraft.getInstance().getConnection() == null) {
+            queue.clear();
+            return;
+        }
         NetworkManager nm = Minecraft.getInstance().getConnection().getConnection();
         while (!queue.isEmpty()) {
             nm.send(queue.poll());

--- a/src/main/java/org/main/vision/actions/SpoofNameHack.java
+++ b/src/main/java/org/main/vision/actions/SpoofNameHack.java
@@ -98,7 +98,13 @@ public class SpoofNameHack extends ActionBase {
         if (!cfg.spoofIncoming) return;
         String alias = cfg.spoofName;
         if (alias == null || alias.isEmpty() || hack.actualName == null) return;
-        hack.replaceStrings(packet, hack.actualName, alias, new java.util.IdentityHashMap<>());
+
+        // Only process chat packets to avoid heavy reflection on every packet
+        if (packet instanceof net.minecraft.network.play.server.SChatPacket) {
+            net.minecraft.util.text.ITextComponent msg =
+                    ((net.minecraft.network.play.server.SChatPacket) packet).getMessage();
+            hack.replaceStrings(msg, hack.actualName, alias, new java.util.IdentityHashMap<>());
+        }
     }
 
     /**
@@ -111,7 +117,18 @@ public class SpoofNameHack extends ActionBase {
         if (!cfg.spoofOutgoing) return;
         String alias = cfg.spoofName;
         if (alias == null || alias.isEmpty() || hack.actualName == null) return;
-        hack.replaceStrings(packet, hack.actualName, alias, new java.util.IdentityHashMap<>());
+
+        // Only modify outgoing chat packets
+        if (packet instanceof net.minecraft.network.play.client.CChatMessagePacket) {
+            try {
+                java.lang.reflect.Field f = net.minecraft.network.play.client.CChatMessagePacket.class.getDeclaredField("message");
+                f.setAccessible(true);
+                String msg = (String) f.get(packet);
+                if (msg != null) {
+                    f.set(packet, msg.replace(hack.actualName, alias));
+                }
+            } catch (Exception ignored) {}
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- avoid NullPointerException in `BlinkHack` when the connection closes
- target only chat packets when spoofing name
- modify outgoing chat packet messages safely

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685c71ec63d0832fa1a56cf2ebab438d