### PR TITLE
Improve DualCam positioning and orientation

### DIFF
--- a/src/main/java/org/main/vision/actions/DualCamHack.java
+++ b/src/main/java/org/main/vision/actions/DualCamHack.java
@@ -16,12 +16,23 @@ public class DualCamHack extends ActionBase {
     private int cameraId;
     private boolean controlling;
 
+    private double startX, startY, startZ;
+    private float bodyYaw, bodyPitch;
+    private boolean hasStart;
+
     @Override
     protected void onEnable() {
         Minecraft mc = Minecraft.getInstance();
         ClientWorld world = mc.level;
         ClientPlayerEntity player = mc.player;
         if (world != null && player != null) {
+            startX = player.getX();
+            startY = player.getY();
+            startZ = player.getZ();
+            bodyYaw = player.yRot;
+            bodyPitch = player.xRot;
+            hasStart = true;
+
             cameraId = -3000 - world.random.nextInt(1000);
             camera = new RemoteClientPlayerEntity(world, player.getGameProfile());
             camera.setId(cameraId);
@@ -35,14 +46,29 @@ public class DualCamHack extends ActionBase {
     protected void onDisable() {
         Minecraft mc = Minecraft.getInstance();
         ClientWorld world = mc.level;
+        ClientPlayerEntity player = mc.player;
         if (world != null && camera != null) {
             world.removeEntity(cameraId);
         }
         if (mc.getCameraEntity() == camera && mc.player != null) {
             mc.setCameraEntity(mc.player);
         }
+        if (player != null && hasStart) {
+            float rotYaw = player.yRot;
+            float rotPitch = player.xRot;
+            if (mc.getCameraEntity() == camera && camera != null) {
+                rotYaw = camera.yRot;
+                rotPitch = camera.xRot;
+            }
+            player.moveTo(startX, startY, startZ, rotYaw, rotPitch);
+            if (player.connection != null) {
+                player.connection.send(new net.minecraft.network.play.client.CPlayerPacket.PositionRotationPacket(
+                        startX, startY, startZ, rotYaw, rotPitch, player.isOnGround()));
+            }
+        }
         camera = null;
         controlling = false;
+        hasStart = false;
     }
 
     /** Toggle between controlling the player and the camera. */
@@ -51,8 +77,13 @@ public class DualCamHack extends ActionBase {
         if (camera == null) return;
         controlling = !controlling;
         if (controlling) {
+            if (mc.player != null) {
+                bodyYaw = mc.player.yRot;
+                bodyPitch = mc.player.xRot;
+            }
             mc.setCameraEntity(camera);
         } else if (mc.player != null) {
+            mc.player.moveTo(mc.player.getX(), mc.player.getY(), mc.player.getZ(), camera.yRot, camera.xRot);
             mc.setCameraEntity(mc.player);
         }
     }
@@ -62,6 +93,18 @@ public class DualCamHack extends ActionBase {
         if (event.phase != TickEvent.Phase.END) return;
         if (!isEnabled() || !controlling || camera == null) return;
         Minecraft mc = Minecraft.getInstance();
+        ClientPlayerEntity player = mc.player;
+
+        if (player != null) {
+            player.setDeltaMovement(0, 0, 0);
+            player.yRot = bodyYaw;
+            player.xRot = bodyPitch;
+            player.yHeadRot = bodyYaw;
+            if (player.connection != null) {
+                player.connection.send(new net.minecraft.network.play.client.CPlayerPacket.PositionRotationPacket(
+                        player.getX(), player.getY(), player.getZ(), bodyYaw, bodyPitch, player.isOnGround()));
+            }
+        }
 
         double speed = 0.5D;
         double y = 0.0D;


### PR DESCRIPTION
## Summary
- remember original player position when DualCam is enabled
- freeze player orientation while controlling the camera
- restore player to starting position when DualCam is disabled
- sync orientation correctly when exiting and reentering the body

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_685c873946ac832fa7c2b75fd3b29dc8