### PR TITLE
Add GhostPredict and QuickCharge hacks

### DIFF
--- a/src/main/java/org/main/vision/VisionClient.java
+++ b/src/main/java/org/main/vision/VisionClient.java
@@ -27,6 +27,8 @@ import org.main.vision.actions.SeeBarrierHack;
 import org.main.vision.actions.NameTagsHack;
 import org.main.vision.actions.ScaffoldHack;
 import org.main.vision.actions.PerspectiveSwapHack;
+import org.main.vision.actions.QuickChargeHack;
+import org.main.vision.actions.GhostPredictHack;
 import org.main.vision.config.HackSettings;
 
 /**
@@ -55,6 +57,8 @@ public class VisionClient {
     private static final NameTagsHack NAMETAGS_HACK = new NameTagsHack();
     private static final ScaffoldHack SCAFFOLD_HACK = new ScaffoldHack();
     private static final PerspectiveSwapHack PERSPECTIVE_SWAP_HACK = new PerspectiveSwapHack();
+    private static final QuickChargeHack QUICKCHARGE_HACK = new QuickChargeHack();
+    private static final GhostPredictHack GHOSTPREDICT_HACK = new GhostPredictHack();
     private static HackSettings SETTINGS;
 
     static void init() {
@@ -146,6 +150,14 @@ public class VisionClient {
         return PERSPECTIVE_SWAP_HACK;
     }
 
+    public static QuickChargeHack getQuickChargeHack() {
+        return QUICKCHARGE_HACK;
+    }
+
+    public static GhostPredictHack getGhostPredictHack() {
+        return GHOSTPREDICT_HACK;
+    }
+
 
     public static HackSettings getSettings() {
         return SETTINGS;
@@ -219,6 +231,12 @@ public class VisionClient {
         }
         if (event.getKey() == VisionKeybind.scaffoldKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
             SCAFFOLD_HACK.toggle();
+        }
+        if (event.getKey() == VisionKeybind.quickChargeKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
+            QUICKCHARGE_HACK.toggle();
+        }
+        if (event.getKey() == VisionKeybind.ghostPredictKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
+            GHOSTPREDICT_HACK.toggle();
         }
         if (event.getKey() == VisionKeybind.perspectiveSwapKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
             PERSPECTIVE_SWAP_HACK.toggle();

--- a/src/main/java/org/main/vision/VisionKeybind.java
+++ b/src/main/java/org/main/vision/VisionKeybind.java
@@ -29,6 +29,8 @@ public class VisionKeybind {
     public static KeyBinding nameTagsKey;
     public static KeyBinding scaffoldKey;
     public static KeyBinding perspectiveSwapKey;
+    public static KeyBinding quickChargeKey;
+    public static KeyBinding ghostPredictKey;
     public static KeyBinding menuKey;
 
     static void register() {
@@ -53,6 +55,8 @@ public class VisionKeybind {
         nameTagsKey = new KeyBinding("key.vision.nametags", GLFW.GLFW_KEY_F6, "key.categories.vision");
         scaffoldKey = new KeyBinding("key.vision.scaffold", GLFW.GLFW_KEY_F7, "key.categories.vision");
         perspectiveSwapKey = new KeyBinding("key.vision.perspectiveswap", GLFW.GLFW_KEY_F8, "key.categories.vision");
+        quickChargeKey = new KeyBinding("key.vision.quickcharge", GLFW.GLFW_KEY_F9, "key.categories.vision");
+        ghostPredictKey = new KeyBinding("key.vision.ghostpredict", GLFW.GLFW_KEY_F10, "key.categories.vision");
         menuKey = new KeyBinding("key.vision.menu", GLFW.GLFW_KEY_BACKSLASH, "key.categories.vision");
         ClientRegistry.registerKeyBinding(speedKey);
         ClientRegistry.registerKeyBinding(jumpKey);
@@ -75,6 +79,8 @@ public class VisionKeybind {
         ClientRegistry.registerKeyBinding(nameTagsKey);
         ClientRegistry.registerKeyBinding(scaffoldKey);
         ClientRegistry.registerKeyBinding(perspectiveSwapKey);
+        ClientRegistry.registerKeyBinding(quickChargeKey);
+        ClientRegistry.registerKeyBinding(ghostPredictKey);
         ClientRegistry.registerKeyBinding(menuKey);
     }
 }

--- a/src/main/java/org/main/vision/VisionMenuScreen.java
+++ b/src/main/java/org/main/vision/VisionMenuScreen.java
@@ -56,6 +56,8 @@ public class VisionMenuScreen extends Screen {
         addEntry(() -> getNameTagsLabel(), this::toggleNameTags, null);
         addEntry(() -> getScaffoldLabel(), this::toggleScaffold, null);
         addEntry(() -> getPerspectiveSwapLabel(), this::togglePerspectiveSwap, null);
+        addEntry(() -> getQuickChargeLabel(), this::toggleQuickCharge, null);
+        addEntry(() -> getGhostPredictLabel(), this::toggleGhostPredict, null);
         layoutButtons();
     }
 
@@ -139,6 +141,8 @@ public class VisionMenuScreen extends Screen {
     private void toggleNameTags() { VisionClient.getNameTagsHack().toggle(); }
     private void toggleScaffold() { VisionClient.getScaffoldHack().toggle(); }
     private void togglePerspectiveSwap() { VisionClient.getPerspectiveSwapHack().toggle(); }
+    private void toggleQuickCharge() { VisionClient.getQuickChargeHack().toggle(); }
+    private void toggleGhostPredict() { VisionClient.getGhostPredictHack().toggle(); }
 
     // Settings open methods
     private void openSpeedSettings() { this.minecraft.setScreen(new SpeedSettingsScreen(this)); }
@@ -175,4 +179,6 @@ public class VisionMenuScreen extends Screen {
     private StringTextComponent getNameTagsLabel() { return new StringTextComponent((VisionClient.getNameTagsHack().isEnabled() ? "Disable" : "Enable") + " NameTags++"); }
     private StringTextComponent getScaffoldLabel() { return new StringTextComponent((VisionClient.getScaffoldHack().isEnabled() ? "Disable" : "Enable") + " Scaffold"); }
     private StringTextComponent getPerspectiveSwapLabel() { return new StringTextComponent((VisionClient.getPerspectiveSwapHack().isEnabled() ? "Disable" : "Enable") + " PerspectiveSwap"); }
+    private StringTextComponent getQuickChargeLabel() { return new StringTextComponent((VisionClient.getQuickChargeHack().isEnabled() ? "Disable" : "Enable") + " QuickCharge"); }
+    private StringTextComponent getGhostPredictLabel() { return new StringTextComponent((VisionClient.getGhostPredictHack().isEnabled() ? "Disable" : "Enable") + " GhostPredict"); }
 }

--- a/src/main/java/org/main/vision/VisionOverlay.java
+++ b/src/main/java/org/main/vision/VisionOverlay.java
@@ -138,6 +138,18 @@ public class VisionOverlay {
             mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
             y += mc.font.lineHeight;
         }
+        if (VisionClient.getQuickChargeHack().isEnabled()) {
+            String text = "QuickCharge";
+            int w = mc.font.width(text);
+            mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
+            y += mc.font.lineHeight;
+        }
+        if (VisionClient.getGhostPredictHack().isEnabled()) {
+            String text = "GhostPredict";
+            int w = mc.font.width(text);
+            mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
+            y += mc.font.lineHeight;
+        }
         if (VisionClient.getPerspectiveSwapHack().isEnabled()) {
             String text = "PerspectiveSwap";
             int w = mc.font.width(text);

--- a/src/main/java/org/main/vision/actions/GhostPredictHack.java
+++ b/src/main/java/org/main/vision/actions/GhostPredictHack.java
@@ -1,0 +1,47 @@
+package org.main.vision.actions;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.player.RemoteClientPlayerEntity;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.entity.EntityRendererManager;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.vector.Vector3d;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+/**
+ * Predicts other players' movement and renders translucent ghosts ahead of them.
+ */
+public class GhostPredictHack extends ActionBase {
+    @SubscribeEvent
+    public void onRenderWorldLast(RenderWorldLastEvent event) {
+        if (!isEnabled()) return;
+        Minecraft mc = Minecraft.getInstance();
+        ClientWorld world = mc.level;
+        PlayerEntity self = mc.player;
+        if (world == null || self == null) return;
+
+        MatrixStack ms = event.getMatrixStack();
+        IRenderTypeBuffer.Impl buffer = mc.renderBuffers().bufferSource();
+        EntityRendererManager rm = mc.getEntityRenderDispatcher();
+        Vector3d cam = mc.gameRenderer.getMainCamera().getPosition();
+        float partial = event.getPartialTicks();
+
+        for (PlayerEntity p : world.players()) {
+            if (p == self) continue;
+            Vector3d predicted = p.position().add(p.getDeltaMovement().scale(20.0D));
+            RemoteClientPlayerEntity ghost = new RemoteClientPlayerEntity(world, new GameProfile(p.getUUID(), p.getName().getString()));
+            ghost.yRot = p.yRot;
+            ghost.xRot = p.xRot;
+            ghost.yHeadRot = p.yHeadRot;
+            ms.pushPose();
+            ms.translate(predicted.x - cam.x, predicted.y - cam.y, predicted.z - cam.z);
+            rm.render(ghost, 0.0D, 0.0D, 0.0D, ghost.yRot, partial, ms, buffer, 0x00F000F0);
+            ms.popPose();
+        }
+        buffer.endBatch();
+    }
+}

--- a/src/main/java/org/main/vision/actions/NameTagsHack.java
+++ b/src/main/java/org/main/vision/actions/NameTagsHack.java
@@ -25,8 +25,12 @@ public class NameTagsHack extends ActionBase {
         Vector3d camPos = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
         double dist = entity.position().distanceTo(camPos);
         String name = entity.getName().getString();
-        String text = String.format("%s [%.0f%% %.1fm]", name,
-                (entity.getHealth() / Math.max(1.0f, entity.getMaxHealth())) * 100.0f, dist);
+        String health = String.format("HP: %.0f%%",
+                (entity.getHealth() / Math.max(1.0f, entity.getMaxHealth())) * 100.0f);
+        String distance = String.format("Dist: %.1fm", dist);
+        String coords = String.format("XYZ: %d %d %d",
+                (int) entity.getX(), (int) entity.getY(), (int) entity.getZ());
+        String[] lines = new String[] { name, health + " " + distance, coords };
 
         MatrixStack ms = event.getMatrixStack();
         EntityRendererManager rm = Minecraft.getInstance().getEntityRenderDispatcher();
@@ -35,8 +39,21 @@ public class NameTagsHack extends ActionBase {
         ms.mulPose(rm.cameraOrientation());
         ms.scale(-0.025F, -0.025F, 0.025F);
         IRenderTypeBuffer.Impl buffer = Minecraft.getInstance().renderBuffers().bufferSource();
-        float w = Minecraft.getInstance().font.width(text) / 2f;
-        Minecraft.getInstance().font.draw(ms, text, -w, 0, 0xFFFFFFFF);
+
+        int lineHeight = Minecraft.getInstance().font.lineHeight;
+        int boxWidth = 0;
+        for (String s : lines) {
+            boxWidth = Math.max(boxWidth, Minecraft.getInstance().font.width(s));
+        }
+        int half = boxWidth / 2 + 2;
+        net.minecraft.client.gui.AbstractGui.fill(ms, -half, -2, half, lines.length * lineHeight + 2, 0x55000000);
+
+        for (int i = 0; i < lines.length; i++) {
+            String s = lines[i];
+            float x = -Minecraft.getInstance().font.width(s) / 2f;
+            Minecraft.getInstance().font.draw(ms, s, x, i * lineHeight, 0xFFFFFFFF);
+        }
+
         buffer.endBatch(RenderType.lines());
         ms.popPose();
     }

--- a/src/main/java/org/main/vision/actions/PerspectiveSwapHack.java
+++ b/src/main/java/org/main/vision/actions/PerspectiveSwapHack.java
@@ -5,6 +5,7 @@ import net.minecraft.client.entity.player.ClientPlayerEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.EntityRayTraceResult;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 /**
  * Swaps the camera to the entity the player is looking at.
@@ -14,19 +15,24 @@ public class PerspectiveSwapHack extends ActionBase {
 
     @Override
     protected void onEnable() {
+        target = null;
+    }
+
+    @SubscribeEvent
+    public void onClientTick(net.minecraftforge.event.TickEvent.ClientTickEvent event) {
+        if (event.phase != net.minecraftforge.event.TickEvent.Phase.END) return;
+        if (!isEnabled()) return;
         Minecraft mc = Minecraft.getInstance();
         ClientPlayerEntity player = mc.player;
-        if (player == null) {
-            setEnabled(false);
-            return;
-        }
+        if (player == null) return;
+
         RayTraceResult result = player.pick(50.0D, 1.0F, false);
         if (result.getType() == RayTraceResult.Type.ENTITY) {
-            target = ((EntityRayTraceResult) result).getEntity();
-            mc.setCameraEntity(target);
-        } else {
-            target = null;
-            setEnabled(false);
+            Entity newTarget = ((EntityRayTraceResult) result).getEntity();
+            if (newTarget != target) {
+                target = newTarget;
+                mc.setCameraEntity(target);
+            }
         }
     }
 

--- a/src/main/java/org/main/vision/actions/QuickChargeHack.java
+++ b/src/main/java/org/main/vision/actions/QuickChargeHack.java
@@ -1,0 +1,22 @@
+package org.main.vision.actions;
+
+import net.minecraft.client.entity.player.ClientPlayerEntity;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+/** Quickly resets the attack cooldown each tick for instant charged hits. */
+public class QuickChargeHack extends ActionBase {
+    @SubscribeEvent
+    public void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) return;
+        if (!isEnabled()) return;
+        if (!(event.player instanceof ClientPlayerEntity)) return;
+        ClientPlayerEntity player = (ClientPlayerEntity) event.player;
+        // Attempt to reset the attack cooldown so the next hit is critical
+        try {
+            player.resetAttackStrengthTicker();
+        } catch (Throwable t) {
+            // Fallback: ignore if the method is unavailable
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend NameTags++ to show health, distance, and coordinates in a box
- fix PerspectiveSwap to continuously track the looked-at entity
- add new QuickCharge hack for instant melee charge
- add new GhostPredict hack to visualize predicted player positions
- register new keybinds and menu options

## Testing
- `./gradlew compileJava`

------
https://chatgpt.com/codex/tasks/task_e_685c9a0c52a0832f91bad9b1adb846c5