### PR TITLE
Add QuantumTunnel feature

### DIFF
--- a/src/main/java/org/main/vision/QuantumTunnelSettingsScreen.java
+++ b/src/main/java/org/main/vision/QuantumTunnelSettingsScreen.java
@@ -1,0 +1,83 @@
+package org.main.vision;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.util.text.StringTextComponent;
+import org.main.vision.config.HackSettings;
+
+/** Screen to edit QuantumTunnel target coordinates. */
+public class QuantumTunnelSettingsScreen extends Screen {
+    private final Screen parent;
+    private TextFieldWidget xField;
+    private TextFieldWidget yField;
+    private TextFieldWidget zField;
+    private PurpleButton applyButton;
+    private double originalX;
+    private double originalY;
+    private double originalZ;
+
+    public QuantumTunnelSettingsScreen(Screen parent) {
+        super(new StringTextComponent("QuantumTunnel Settings"));
+        this.parent = parent;
+    }
+
+    @Override
+    protected void init() {
+        HackSettings cfg = VisionClient.getSettings();
+        int centerX = this.width / 2;
+        int centerY = this.height / 2;
+        int fieldWidth = 80;
+        xField = new TextFieldWidget(this.font, centerX - fieldWidth - 5, centerY - 10, fieldWidth, 20, new StringTextComponent("X"));
+        yField = new TextFieldWidget(this.font, centerX - fieldWidth / 2, centerY - 10, fieldWidth, 20, new StringTextComponent("Y"));
+        zField = new TextFieldWidget(this.font, centerX + 5 + fieldWidth / 2, centerY - 10, fieldWidth, 20, new StringTextComponent("Z"));
+        xField.setMaxLength(32);
+        yField.setMaxLength(32);
+        zField.setMaxLength(32);
+        originalX = cfg.quantumX;
+        originalY = cfg.quantumY;
+        originalZ = cfg.quantumZ;
+        xField.setValue(Double.toString(originalX));
+        yField.setValue(Double.toString(originalY));
+        zField.setValue(Double.toString(originalZ));
+        addWidget(xField);
+        addWidget(yField);
+        addWidget(zField);
+        int y = centerY + 20;
+        applyButton = addButton(new PurpleButton(centerX - 60, y, 120, 20, new StringTextComponent("Apply"), b -> apply()));
+        y += 24;
+        addButton(new PurpleButton(centerX - 60, y, 120, 20, new StringTextComponent("Back"), b -> onClose()));
+    }
+
+    @Override
+    public void render(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
+        this.renderBackground(ms);
+        xField.render(ms, mouseX, mouseY, partialTicks);
+        yField.render(ms, mouseX, mouseY, partialTicks);
+        zField.render(ms, mouseX, mouseY, partialTicks);
+        boolean changed = !xField.getValue().equals(Double.toString(originalX)) ||
+                !yField.getValue().equals(Double.toString(originalY)) ||
+                !zField.getValue().equals(Double.toString(originalZ));
+        applyButton.active = changed;
+        super.render(ms, mouseX, mouseY, partialTicks);
+    }
+
+    @Override
+    public void onClose() {
+        this.minecraft.setScreen(parent);
+    }
+
+    private void apply() {
+        HackSettings cfg = VisionClient.getSettings();
+        try {
+            cfg.quantumX = Double.parseDouble(xField.getValue());
+            cfg.quantumY = Double.parseDouble(yField.getValue());
+            cfg.quantumZ = Double.parseDouble(zField.getValue());
+            originalX = cfg.quantumX;
+            originalY = cfg.quantumY;
+            originalZ = cfg.quantumZ;
+            VisionClient.saveSettings();
+            VisionClient.getQuantumTunnelHack().setTarget(cfg.quantumX, cfg.quantumY, cfg.quantumZ);
+        } catch (NumberFormatException ignored) {}
+    }
+}

--- a/src/main/java/org/main/vision/VisionClient.java
+++ b/src/main/java/org/main/vision/VisionClient.java
@@ -27,6 +27,7 @@ import org.main.vision.actions.NameTagsHack;
 import org.main.vision.actions.ScaffoldHack;
 import org.main.vision.actions.QuickChargeHack;
 import org.main.vision.actions.ItemMagnetHack;
+import org.main.vision.actions.QuantumTunnelHack;
 import org.main.vision.config.HackSettings;
 
 /**
@@ -55,11 +56,13 @@ public class VisionClient {
     private static final ScaffoldHack SCAFFOLD_HACK = new ScaffoldHack();
     private static final QuickChargeHack QUICKCHARGE_HACK = new QuickChargeHack();
     private static final ItemMagnetHack ITEMMAGNET_HACK = new ItemMagnetHack();
+    private static final QuantumTunnelHack QUANTUMTUNNEL_HACK = new QuantumTunnelHack();
     private static HackSettings SETTINGS;
 
     static void init() {
         VisionKeybind.register();
         SETTINGS = HackSettings.load();
+        QUANTUMTUNNEL_HACK.setTarget(SETTINGS.quantumX, SETTINGS.quantumY, SETTINGS.quantumZ);
     }
 
     public static SpeedHack getSpeedHack() {
@@ -146,6 +149,10 @@ public class VisionClient {
         return ITEMMAGNET_HACK;
     }
 
+    public static QuantumTunnelHack getQuantumTunnelHack() {
+        return QUANTUMTUNNEL_HACK;
+    }
+
 
     public static HackSettings getSettings() {
         return SETTINGS;
@@ -222,6 +229,9 @@ public class VisionClient {
         }
         if (event.getKey() == VisionKeybind.itemMagnetKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
             ITEMMAGNET_HACK.toggle();
+        }
+        if (event.getKey() == VisionKeybind.quantumTunnelKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS && Minecraft.getInstance().screen == null) {
+            QUANTUMTUNNEL_HACK.toggle();
         }
         if (event.getKey() == VisionKeybind.menuKey.getKey().getValue() && event.getAction() == GLFW.GLFW_PRESS) {
             Minecraft.getInstance().setScreen(new VisionMenuScreen());

--- a/src/main/java/org/main/vision/VisionKeybind.java
+++ b/src/main/java/org/main/vision/VisionKeybind.java
@@ -29,6 +29,7 @@ public class VisionKeybind {
     public static KeyBinding scaffoldKey;
     public static KeyBinding quickChargeKey;
     public static KeyBinding itemMagnetKey;
+    public static KeyBinding quantumTunnelKey;
     public static KeyBinding menuKey;
 
     static void register() {
@@ -53,6 +54,7 @@ public class VisionKeybind {
         scaffoldKey = new KeyBinding("key.vision.scaffold", GLFW.GLFW_KEY_F7, "key.categories.vision");
         quickChargeKey = new KeyBinding("key.vision.quickcharge", GLFW.GLFW_KEY_F9, "key.categories.vision");
         itemMagnetKey = new KeyBinding("key.vision.itemmagnet", GLFW.GLFW_KEY_F11, "key.categories.vision");
+        quantumTunnelKey = new KeyBinding("key.vision.quantumtunnel", GLFW.GLFW_KEY_F12, "key.categories.vision");
         menuKey = new KeyBinding("key.vision.menu", GLFW.GLFW_KEY_BACKSLASH, "key.categories.vision");
         ClientRegistry.registerKeyBinding(speedKey);
         ClientRegistry.registerKeyBinding(jumpKey);
@@ -75,6 +77,7 @@ public class VisionKeybind {
         ClientRegistry.registerKeyBinding(scaffoldKey);
         ClientRegistry.registerKeyBinding(quickChargeKey);
         ClientRegistry.registerKeyBinding(itemMagnetKey);
+        ClientRegistry.registerKeyBinding(quantumTunnelKey);
         ClientRegistry.registerKeyBinding(menuKey);
     }
 }

--- a/src/main/java/org/main/vision/VisionMenuScreen.java
+++ b/src/main/java/org/main/vision/VisionMenuScreen.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.util.text.StringTextComponent;
+import org.main.vision.QuantumTunnelSettingsScreen;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,6 +57,7 @@ public class VisionMenuScreen extends Screen {
         addEntry(() -> getScaffoldLabel(), this::toggleScaffold, null);
         addEntry(() -> getQuickChargeLabel(), this::toggleQuickCharge, null);
         addEntry(() -> getItemMagnetLabel(), this::toggleItemMagnet, null);
+        addEntry(() -> getQuantumTunnelLabel(), this::toggleQuantumTunnel, this::openQuantumTunnelSettings);
         layoutButtons();
     }
 
@@ -139,6 +141,7 @@ public class VisionMenuScreen extends Screen {
     private void toggleScaffold() { VisionClient.getScaffoldHack().toggle(); }
     private void toggleQuickCharge() { VisionClient.getQuickChargeHack().toggle(); }
     private void toggleItemMagnet() { VisionClient.getItemMagnetHack().toggle(); }
+    private void toggleQuantumTunnel() { VisionClient.getQuantumTunnelHack().toggle(); }
 
     // Settings open methods
     private void openSpeedSettings() { this.minecraft.setScreen(new SpeedSettingsScreen(this)); }
@@ -151,6 +154,7 @@ public class VisionMenuScreen extends Screen {
     private void openNoFallSettings() { this.minecraft.setScreen(new HackSettingsScreen(this, "Threshold", () -> VisionClient.getSettings().noFallThreshold,
             v -> { VisionClient.getSettings().noFallThreshold = v; }, VisionClient::saveSettings, 2.0D)); }
     private void openXRaySettings() { this.minecraft.setScreen(new XRaySettingsScreen(this)); }
+    private void openQuantumTunnelSettings() { this.minecraft.setScreen(new QuantumTunnelSettingsScreen(this)); }
     
 
     // Label helpers
@@ -175,4 +179,5 @@ public class VisionMenuScreen extends Screen {
     private StringTextComponent getScaffoldLabel() { return new StringTextComponent((VisionClient.getScaffoldHack().isEnabled() ? "Disable" : "Enable") + " Scaffold"); }
     private StringTextComponent getQuickChargeLabel() { return new StringTextComponent((VisionClient.getQuickChargeHack().isEnabled() ? "Disable" : "Enable") + " QuickCharge"); }
     private StringTextComponent getItemMagnetLabel() { return new StringTextComponent((VisionClient.getItemMagnetHack().isEnabled() ? "Disable" : "Enable") + " ItemMagnet"); }
+    private StringTextComponent getQuantumTunnelLabel() { return new StringTextComponent((VisionClient.getQuantumTunnelHack().isEnabled() ? "Disable" : "Enable") + " QuantumTunnel"); }
 }

--- a/src/main/java/org/main/vision/VisionOverlay.java
+++ b/src/main/java/org/main/vision/VisionOverlay.java
@@ -144,5 +144,11 @@ public class VisionOverlay {
             mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
             y += mc.font.lineHeight;
         }
+        if (VisionClient.getQuantumTunnelHack().isEnabled()) {
+            String text = "QuantumTunnel";
+            int w = mc.font.width(text);
+            mc.font.draw(ms, text, width - w - 5, y, 0xFFAA55FF);
+            y += mc.font.lineHeight;
+        }
     }
 }

--- a/src/main/java/org/main/vision/actions/QuantumTunnelHack.java
+++ b/src/main/java/org/main/vision/actions/QuantumTunnelHack.java
@@ -1,0 +1,70 @@
+package org.main.vision.actions;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.player.ClientPlayerEntity;
+import net.minecraft.client.entity.player.RemoteClientPlayerEntity;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+/**
+ * Experimental remote camera that lets the player view a distant location.
+ * Interaction is not implemented but the camera can look around remotely.
+ */
+public class QuantumTunnelHack extends ActionBase {
+    private RemoteClientPlayerEntity cameraEntity;
+    private int cameraId;
+    private double targetX;
+    private double targetY;
+    private double targetZ;
+
+    /** Set the target coordinates for the remote view. */
+    public void setTarget(double x, double y, double z) {
+        this.targetX = x;
+        this.targetY = y;
+        this.targetZ = z;
+    }
+
+    @Override
+    protected void onEnable() {
+        Minecraft mc = Minecraft.getInstance();
+        ClientWorld world = mc.level;
+        ClientPlayerEntity player = mc.player;
+        if (world == null || player == null) return;
+        cameraId = -4000 - world.random.nextInt(1000);
+        cameraEntity = new RemoteClientPlayerEntity(world, new GameProfile(player.getGameProfile().getId(), "QuantumCam"));
+        cameraEntity.setId(cameraId);
+        cameraEntity.moveTo(targetX, targetY, targetZ, player.yRot, player.xRot);
+        world.addPlayer(cameraId, cameraEntity);
+        mc.setCameraEntity(cameraEntity);
+    }
+
+    @Override
+    protected void onDisable() {
+        Minecraft mc = Minecraft.getInstance();
+        ClientWorld world = mc.level;
+        ClientPlayerEntity player = mc.player;
+        if (world != null && cameraEntity != null) {
+            world.removeEntity(cameraId);
+            cameraEntity = null;
+        }
+        if (player != null) {
+            mc.setCameraEntity(player);
+        }
+    }
+
+    @SubscribeEvent
+    public void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) return;
+        if (!isEnabled()) return;
+        if (cameraEntity == null) return;
+        Minecraft mc = Minecraft.getInstance();
+        ClientPlayerEntity player = mc.player;
+        if (player == null) return;
+        // Keep camera rotation in sync with player's current view
+        cameraEntity.yRot = player.yRot;
+        cameraEntity.xRot = player.xRot;
+        cameraEntity.yHeadRot = player.yRot;
+    }
+}

--- a/src/main/java/org/main/vision/config/HackSettings.java
+++ b/src/main/java/org/main/vision/config/HackSettings.java
@@ -30,6 +30,13 @@ public class HackSettings {
     /** List of block ids highlighted by XRayHack. */
     public java.util.List<String> xrayBlocks = new java.util.ArrayList<>();
 
+    /** Target X coordinate for QuantumTunnel. */
+    public double quantumX = 0.0D;
+    /** Target Y coordinate for QuantumTunnel. */
+    public double quantumY = 64.0D;
+    /** Target Z coordinate for QuantumTunnel. */
+    public double quantumZ = 0.0D;
+
 
 
     /** Helper to check if a block should be highlighted. */


### PR DESCRIPTION
## Summary
- add QuantumTunnelHack to allow a remote camera view
- register a keybind for QuantumTunnel
- allow editing QuantumTunnel target coordinates
- display QuantumTunnel state in overlay and menu
- persist coordinates in hack settings

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685ca9587f18832fa8eb021f126c0cbc